### PR TITLE
feat: Counter APIにbatchGet・sumByPrefix・batchCreateを追加

### DIFF
--- a/apps/api/src/routes/like.ts
+++ b/apps/api/src/routes/like.ts
@@ -17,6 +17,7 @@ import { hashToken, verifyToken, validateOwnerToken } from "../lib/core/auth";
 import { generatePublicId } from "../lib/core/id";
 import { generateUserHash } from "../lib/core/crypto";
 import { getTodayDateString } from "../lib/core/db";
+import { URL_CONST } from "../lib/core/constants";
 import { sendWebHook, WebHookMessages } from "../lib/core/webhook";
 
 type Bindings = { DB: D1Database };
@@ -143,9 +144,14 @@ app.get("/", async (c) => {
       return c.json({ error: "Invalid prefix format" }, 400);
     }
 
+    // LIKE ワイルドカードとしての _ をエスケープ
+    const escapedPrefix = prefix.replace(/_/g, "\\_");
+
     const row = await db
-      .prepare("SELECT COALESCE(SUM(total), 0) as total FROM likes WHERE service_id LIKE ?")
-      .bind(`like:${prefix}%:total`)
+      .prepare(
+        "SELECT COALESCE(SUM(total), 0) as total FROM likes WHERE service_id LIKE ? ESCAPE '\\'"
+      )
+      .bind(`like:${escapedPrefix}%:total`)
       .first<{ total: number }>();
 
     return c.json({ success: true, total: row?.total ?? 0 });
@@ -466,6 +472,12 @@ app.post("/", async (c) => {
       }
       if (!validIdPattern.test(item.id) || item.id.length > 128) {
         return c.json({ error: `Invalid id format: ${item.id}` }, 400);
+      }
+      if (!item.url.startsWith(URL_CONST.REQUIRED_PROTOCOL)) {
+        return c.json(
+          { error: `URL must start with ${URL_CONST.REQUIRED_PROTOCOL}: ${item.url}` },
+          400
+        );
       }
     }
 

--- a/apps/api/src/routes/visit.ts
+++ b/apps/api/src/routes/visit.ts
@@ -263,9 +263,14 @@ app.get("/", async (c) => {
       return c.json({ error: "Invalid prefix format" }, 400);
     }
 
+    // LIKE ワイルドカードとしての _ をエスケープ
+    const escapedPrefix = prefix.replace(/_/g, "\\_");
+
     const row = await db
-      .prepare("SELECT COALESCE(SUM(total), 0) as total FROM counters WHERE service_id LIKE ?")
-      .bind(`counter:${prefix}%:total`)
+      .prepare(
+        "SELECT COALESCE(SUM(total), 0) as total FROM counters WHERE service_id LIKE ? ESCAPE '\\'"
+      )
+      .bind(`counter:${escapedPrefix}%:total`)
       .first<{ total: number }>();
 
     return c.json({ success: true, total: row?.total ?? 0 });
@@ -550,6 +555,12 @@ app.post("/", async (c) => {
       }
       if (!validIdPattern.test(item.id) || item.id.length > 128) {
         return c.json({ error: `Invalid id format: ${item.id}` }, 400);
+      }
+      if (!item.url.startsWith(URL_CONST.REQUIRED_PROTOCOL)) {
+        return c.json(
+          { error: `URL must start with ${URL_CONST.REQUIRED_PROTOCOL}: ${item.url}` },
+          400
+        );
       }
     }
 

--- a/apps/api/src/routes/visit.ts
+++ b/apps/api/src/routes/visit.ts
@@ -1,13 +1,16 @@
 /**
  * Visit (Counter) API Routes
  *
- * GET  /?action=get        - Public read (by id)
- * GET  /?action=increment  - Increment counter (by id)
- * POST /?action=get        - Owner read (body: url, token) - token never in URL
- * POST /?action=create     - Create a new counter (body: url, token, webhookUrl?)
- * POST /?action=update     - Update counter settings (body: url, token, value?, webhookUrl?)
- * POST /?action=set        - Set counter value (deprecated, use update) (body: url, token, value)
- * POST /?action=delete     - Delete counter (body: url, token)
+ * GET  /?action=get          - Public read (by id)
+ * GET  /?action=increment    - Increment counter (by id)
+ * GET  /?action=sumByPrefix  - Sum counters by prefix
+ * POST /?action=get          - Owner read (body: url, token) - token never in URL
+ * POST /?action=create       - Create a new counter (body: url, token, webhookUrl?)
+ * POST /?action=update       - Update counter settings (body: url, token, value?, webhookUrl?)
+ * POST /?action=set          - Set counter value (deprecated, use update) (body: url, token, value)
+ * POST /?action=delete       - Delete counter (body: url, token)
+ * POST /?action=batchCreate  - Batch create (body: token, items)
+ * POST /?action=batchGet     - Batch get (body: ids)
  */
 
 import { Hono } from "hono";
@@ -250,10 +253,28 @@ app.get("/", async (c) => {
     return c.json({ success: true, data });
   }
 
+  // SUM BY PREFIX
+  if (action === "sumByPrefix") {
+    const prefix = c.req.query("prefix");
+    if (!prefix) {
+      return c.json({ error: "prefix is required" }, 400);
+    }
+    if (!/^[a-zA-Z0-9_-]+$/.test(prefix)) {
+      return c.json({ error: "Invalid prefix format" }, 400);
+    }
+
+    const row = await db
+      .prepare("SELECT COALESCE(SUM(total), 0) as total FROM counters WHERE service_id LIKE ?")
+      .bind(`counter:${prefix}%:total`)
+      .first<{ total: number }>();
+
+    return c.json({ success: true, total: row?.total ?? 0 });
+  }
+
   return c.json(
     {
       error:
-        "Invalid action. Use GET: get, increment. Use POST: get (owner), create, update, set, delete",
+        "Invalid action. Use GET: get, increment, sumByPrefix. Use POST: get (owner), create, update, set, delete, batchGet, batchCreate",
     },
     400
   );
@@ -504,8 +525,131 @@ app.post("/", async (c) => {
     return c.json({ success: true, message: "Counter deleted" });
   }
 
+  // BATCH CREATE
+  if (action === "batchCreate") {
+    const token = body.token as string | undefined;
+    const items = body.items as Array<{ id: string; url: string }> | undefined;
+
+    if (!token || !validateOwnerToken(token)) {
+      return c.json({ error: "Valid token is required" }, 400);
+    }
+
+    if (!Array.isArray(items) || items.length === 0) {
+      return c.json({ error: "items array is required and must not be empty" }, 400);
+    }
+
+    const MAX_BATCH_SIZE = 100;
+    if (items.length > MAX_BATCH_SIZE) {
+      return c.json({ error: `Maximum ${MAX_BATCH_SIZE} items per request` }, 400);
+    }
+
+    const validIdPattern = /^[a-zA-Z0-9_-]+$/;
+    for (const item of items) {
+      if (!item.id || !item.url) {
+        return c.json({ error: "Each item must have id and url" }, 400);
+      }
+      if (!validIdPattern.test(item.id) || item.id.length > 128) {
+        return c.json({ error: `Invalid id format: ${item.id}` }, 400);
+      }
+    }
+
+    const hashedToken = await hashToken(token);
+    let created = 0;
+    let skipped = 0;
+
+    for (const item of items) {
+      const existingById = await getCounterById(db, item.id);
+      if (existingById) {
+        skipped++;
+        continue;
+      }
+      const existingByUrl = await getCounterByUrl(db, item.url);
+      if (existingByUrl) {
+        skipped++;
+        continue;
+      }
+
+      const metadata = JSON.stringify({ webhookUrl: null });
+
+      await db.batch([
+        db
+          .prepare(
+            'INSERT INTO services (id, type, url, metadata, created_at) VALUES (?, ?, ?, ?, datetime("now"))'
+          )
+          .bind(`counter:${item.id}`, "counter", item.url, metadata),
+        db
+          .prepare("INSERT INTO url_mappings (type, url, service_id) VALUES (?, ?, ?)")
+          .bind("counter", item.url, item.id),
+        db
+          .prepare("INSERT INTO owner_tokens (service_id, token_hash) VALUES (?, ?)")
+          .bind(`counter:${item.id}`, hashedToken),
+        db
+          .prepare("INSERT INTO counters (service_id, total) VALUES (?, 0)")
+          .bind(`counter:${item.id}:total`),
+      ]);
+      created++;
+    }
+
+    return c.json({ success: true, created, skipped });
+  }
+
+  // BATCH GET
+  if (action === "batchGet") {
+    const ids = body.ids as string[] | undefined;
+
+    if (!Array.isArray(ids) || ids.length === 0) {
+      return c.json({ error: "ids array is required and must not be empty" }, 400);
+    }
+
+    // 上限チェック（パフォーマンス保護）
+    const MAX_BATCH_SIZE = 1000;
+    if (ids.length > MAX_BATCH_SIZE) {
+      return c.json({ error: `Maximum ${MAX_BATCH_SIZE} ids per request` }, 400);
+    }
+
+    // IDバリデーション（英数字とハイフンのみ許可）
+    const validIdPattern = /^[a-zA-Z0-9_-]+$/;
+    for (const id of ids) {
+      if (!validIdPattern.test(id)) {
+        return c.json({ error: `Invalid id format: ${id}` }, 400);
+      }
+    }
+
+    // service_idのリストを構築
+    const serviceIds = ids.map((id) => `counter:${id}:total`);
+
+    // D1はIN句のプレースホルダを動的に構築する必要がある
+    const placeholders = serviceIds.map(() => "?").join(",");
+    const query = `SELECT service_id, total FROM counters WHERE service_id IN (${placeholders})`;
+
+    const result = await db
+      .prepare(query)
+      .bind(...serviceIds)
+      .all<{ service_id: string; total: number }>();
+
+    // 結果をIDでマップ
+    const data: Record<string, { total: number }> = {};
+    for (const row of result.results || []) {
+      // "counter:xxx:total" から "xxx" を抽出
+      const id = row.service_id.replace(/^counter:/, "").replace(/:total$/, "");
+      data[id] = { total: row.total };
+    }
+
+    // リクエストされたが存在しないIDは0として含める
+    for (const id of ids) {
+      if (!data[id]) {
+        data[id] = { total: 0 };
+      }
+    }
+
+    return c.json({ success: true, data });
+  }
+
   return c.json(
-    { error: "Invalid action for POST. Use: get (owner), create, update, set, delete" },
+    {
+      error:
+        "Invalid action for POST. Use: get (owner), create, update, set, delete, batchGet, batchCreate",
+    },
     400
   );
 });

--- a/docs/user-guide/api.md
+++ b/docs/user-guide/api.md
@@ -22,7 +22,7 @@ Just like the original 1990s web tools, everything can be operated directly from
 4. **Easy sharing**: Every operation is a shareable URL
 5. **BBS culture**: Even message posting uses GET parameters, just like the old days
 
-> **Note**: The only exception is `Like.batchGet` which uses POST to handle large ID arrays (up to 1000) that exceed URL length limits.
+> **Note**: `batchGet` and `batchCreate` use POST to handle large request bodies that exceed URL length limits. This applies to both Counter and Like services.
 
 ## Services
 

--- a/docs/user-guide/services/counter.md
+++ b/docs/user-guide/services/counter.md
@@ -329,6 +329,107 @@ document.querySelector("#counter").src =
   `/api/visit?action=get&id=blog-a7b9c3d4&type=total&theme=light`;
 ```
 
+### sumByPrefix
+
+Sum counter values by ID prefix. Useful for aggregating all counters under a common prefix (e.g., all pages of a site).
+
+```
+GET /api/visit?action=sumByPrefix&prefix={PREFIX}
+```
+
+**Parameters:**
+
+- `prefix` (required): ID prefix to match (alphanumeric, hyphens, underscores only)
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "total": 1234
+}
+```
+
+**Usage Example:**
+
+```javascript
+// Sum all counters for osaka-kenpo (e.g., osaka-kenpo-art1, osaka-kenpo-art2, ...)
+const response = await fetch("/api/visit?action=sumByPrefix&prefix=osaka-kenpo");
+const { total } = await response.json();
+console.log("Total views:", total);
+```
+
+### batchGet
+
+> **⚠️ POST Method Required**
+
+Get counter values for multiple IDs in a single request.
+
+```
+POST /api/visit?action=batchGet
+Content-Type: application/json
+
+{
+  "ids": ["id1", "id2", "id3"]
+}
+```
+
+**Request Body:**
+
+- `ids` (required): Array of public counter IDs (max 1000)
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "data": {
+    "id1": { "total": 100 },
+    "id2": { "total": 42 },
+    "id3": { "total": 0 }
+  }
+}
+```
+
+**Notes:**
+
+- IDs that don't exist return `{ "total": 0 }`
+- Maximum 1000 IDs per request
+
+### batchCreate
+
+> **⚠️ POST Method Required**
+
+Create multiple counters in a single request. Existing IDs/URLs are skipped.
+
+```
+POST /api/visit?action=batchCreate
+Content-Type: application/json
+
+{
+  "token": "your-secret",
+  "items": [
+    { "id": "page-1", "url": "https://example.com/page1" },
+    { "id": "page-2", "url": "https://example.com/page2" }
+  ]
+}
+```
+
+**Request Body:**
+
+- `token` (required): Owner token (8-16 characters)
+- `items` (required): Array of `{id, url}` objects (max 100)
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "created": 2,
+  "skipped": 0
+}
+```
+
 ## Security Notes
 
 - Owner tokens are stored as SHA256 hashes

--- a/docs/user-guide/services/counter.md
+++ b/docs/user-guide/services/counter.md
@@ -202,6 +202,107 @@ GET /api/visit?action=delete&url={URL}&token={TOKEN}
 }
 ```
 
+### sumByPrefix
+
+Sum counter values by ID prefix. Useful for aggregating all counters under a common prefix (e.g., all pages of a site).
+
+```
+GET /api/visit?action=sumByPrefix&prefix={PREFIX}
+```
+
+**Parameters:**
+
+- `prefix` (required): ID prefix to match (alphanumeric, hyphens, underscores only)
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "total": 1234
+}
+```
+
+**Usage Example:**
+
+```javascript
+// Sum all counters for osaka-kenpo (e.g., osaka-kenpo-art1, osaka-kenpo-art2, ...)
+const response = await fetch("/api/visit?action=sumByPrefix&prefix=osaka-kenpo");
+const { total } = await response.json();
+console.log("Total views:", total);
+```
+
+### batchGet
+
+> **⚠️ POST Method Required**
+
+Get counter values for multiple IDs in a single request.
+
+```
+POST /api/visit?action=batchGet
+Content-Type: application/json
+
+{
+  "ids": ["id1", "id2", "id3"]
+}
+```
+
+**Request Body:**
+
+- `ids` (required): Array of public counter IDs (max 1000)
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "data": {
+    "id1": { "total": 100 },
+    "id2": { "total": 42 },
+    "id3": { "total": 0 }
+  }
+}
+```
+
+**Notes:**
+
+- IDs that don't exist return `{ "total": 0 }`
+- Maximum 1000 IDs per request
+
+### batchCreate
+
+> **⚠️ POST Method Required**
+
+Create multiple counters in a single request. Existing IDs/URLs are skipped.
+
+```
+POST /api/visit?action=batchCreate
+Content-Type: application/json
+
+{
+  "token": "your-secret",
+  "items": [
+    { "id": "page-1", "url": "https://example.com/page1" },
+    { "id": "page-2", "url": "https://example.com/page2" }
+  ]
+}
+```
+
+**Request Body:**
+
+- `token` (required): Owner token (8-16 characters)
+- `items` (required): Array of `{id, url}` objects (max 100)
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "created": 2,
+  "skipped": 0
+}
+```
+
 ## Web Component Integration
 
 ```html
@@ -327,107 +428,6 @@ const data = await count.json();
 // Get as image
 document.querySelector("#counter").src =
   `/api/visit?action=get&id=blog-a7b9c3d4&type=total&theme=light`;
-```
-
-### sumByPrefix
-
-Sum counter values by ID prefix. Useful for aggregating all counters under a common prefix (e.g., all pages of a site).
-
-```
-GET /api/visit?action=sumByPrefix&prefix={PREFIX}
-```
-
-**Parameters:**
-
-- `prefix` (required): ID prefix to match (alphanumeric, hyphens, underscores only)
-
-**Response:**
-
-```json
-{
-  "success": true,
-  "total": 1234
-}
-```
-
-**Usage Example:**
-
-```javascript
-// Sum all counters for osaka-kenpo (e.g., osaka-kenpo-art1, osaka-kenpo-art2, ...)
-const response = await fetch("/api/visit?action=sumByPrefix&prefix=osaka-kenpo");
-const { total } = await response.json();
-console.log("Total views:", total);
-```
-
-### batchGet
-
-> **⚠️ POST Method Required**
-
-Get counter values for multiple IDs in a single request.
-
-```
-POST /api/visit?action=batchGet
-Content-Type: application/json
-
-{
-  "ids": ["id1", "id2", "id3"]
-}
-```
-
-**Request Body:**
-
-- `ids` (required): Array of public counter IDs (max 1000)
-
-**Response:**
-
-```json
-{
-  "success": true,
-  "data": {
-    "id1": { "total": 100 },
-    "id2": { "total": 42 },
-    "id3": { "total": 0 }
-  }
-}
-```
-
-**Notes:**
-
-- IDs that don't exist return `{ "total": 0 }`
-- Maximum 1000 IDs per request
-
-### batchCreate
-
-> **⚠️ POST Method Required**
-
-Create multiple counters in a single request. Existing IDs/URLs are skipped.
-
-```
-POST /api/visit?action=batchCreate
-Content-Type: application/json
-
-{
-  "token": "your-secret",
-  "items": [
-    { "id": "page-1", "url": "https://example.com/page1" },
-    { "id": "page-2", "url": "https://example.com/page2" }
-  ]
-}
-```
-
-**Request Body:**
-
-- `token` (required): Owner token (8-16 characters)
-- `items` (required): Array of `{id, url}` objects (max 100)
-
-**Response:**
-
-```json
-{
-  "success": true,
-  "created": 2,
-  "skipped": 0
-}
 ```
 
 ## Security Notes


### PR DESCRIPTION
## 関連 Issue
closes #1

## 変更内容
Like APIに実装済みの3アクションをCounter（Visit）APIに移植:

- **GET `sumByPrefix`**: prefix にマッチする全カウンターの合計を返す
- **POST `batchGet`**: 複数の counterId の値を一括取得（最大1000件）
- **POST `batchCreate`**: 複数のカウンターを一括作成（最大100件、重複スキップ）

Counter固有の違い（テーブル名 `counters`、prefix `counter:`、metadata構造）のみ変更し、Like側の構造を忠実に踏襲。