### PR TITLE
fix: sumByPrefixのアンダースコアエスケープをD1互換に修正

### DIFF
--- a/apps/api/src/routes/like.ts
+++ b/apps/api/src/routes/like.ts
@@ -144,12 +144,12 @@ app.get("/", async (c) => {
       return c.json({ error: "Invalid prefix format" }, 400);
     }
 
-    // LIKE ワイルドカードとしての _ をエスケープ
-    const escapedPrefix = prefix.replace(/_/g, "\\_");
+    // LIKE ワイルドカードとしての _ をエスケープ（D1互換のため ! を使用）
+    const escapedPrefix = prefix.replace(/_/g, "!_");
 
     const row = await db
       .prepare(
-        "SELECT COALESCE(SUM(total), 0) as total FROM likes WHERE service_id LIKE ? ESCAPE '\\'"
+        "SELECT COALESCE(SUM(total), 0) as total FROM likes WHERE service_id LIKE ? ESCAPE '!'"
       )
       .bind(`like:${escapedPrefix}%:total`)
       .first<{ total: number }>();

--- a/apps/api/src/routes/visit.ts
+++ b/apps/api/src/routes/visit.ts
@@ -263,12 +263,12 @@ app.get("/", async (c) => {
       return c.json({ error: "Invalid prefix format" }, 400);
     }
 
-    // LIKE ワイルドカードとしての _ をエスケープ
-    const escapedPrefix = prefix.replace(/_/g, "\\_");
+    // LIKE ワイルドカードとしての _ をエスケープ（D1互換のため ! を使用）
+    const escapedPrefix = prefix.replace(/_/g, "!_");
 
     const row = await db
       .prepare(
-        "SELECT COALESCE(SUM(total), 0) as total FROM counters WHERE service_id LIKE ? ESCAPE '\\'"
+        "SELECT COALESCE(SUM(total), 0) as total FROM counters WHERE service_id LIKE ? ESCAPE '!'"
       )
       .bind(`counter:${escapedPrefix}%:total`)
       .first<{ total: number }>();


### PR DESCRIPTION
## 問題
`sumByPrefix` でプレフィックスにアンダースコア `_` を含むと Internal Server Error が発生。
osaka-kenpo の `jp_hist`, `world_hist`, `german_basic_law` 等のカテゴリ/法律名で閲覧数・ええやん合計が取得できなかった。

## 原因
SQL の `ESCAPE '\'` がCloudflare D1で正しく処理されない。

## 修正
エスケープ文字を `\` から `!` に変更。`_` → `!_` でエスケープ、`ESCAPE '!'` で指定。
Like API (`like.ts`) と Counter API (`visit.ts`) の両方に適用。