### PR TITLE
Add page-wide batch read client

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -18,7 +18,8 @@ const app = new Hono<{ Bindings: Bindings }>();
 // Mutation requests (POST/PUT/DELETE): restrict to *.llll-ll.com + localhost
 app.use("*", async (c, next) => {
   const method = c.req.method;
-  if (method === "GET" || method === "HEAD" || method === "OPTIONS") {
+  const action = c.req.query("action");
+  if (method === "GET" || method === "HEAD" || method === "OPTIONS" || action === "batchGet") {
     return cors({ origin: "*" })(c, next);
   }
   // All *.llll-ll.com subdomains + localhost for development

--- a/apps/api/src/routes/like.ts
+++ b/apps/api/src/routes/like.ts
@@ -69,6 +69,14 @@ async function getUserLikeState(
   return row?.value === "liked";
 }
 
+function stripLikeTotalServiceId(serviceId: string): string {
+  return serviceId.replace(/^like:/, "").replace(/:total$/, "");
+}
+
+function stripLikeServiceId(serviceId: string): string {
+  return serviceId.replace(/^like:/, "");
+}
+
 /** Verify owner token against DB */
 async function verifyOwnerToken(
   db: D1Database,
@@ -546,30 +554,50 @@ app.post("/", async (c) => {
       }
     }
 
+    const uniqueIds = [...new Set(ids)];
+    const ip = c.req.header("CF-Connecting-IP") || c.req.header("X-Forwarded-For") || "0.0.0.0";
+    const userAgent = c.req.header("User-Agent") || "";
+    const userHash = await generateUserHash(ip, userAgent);
+    const today = getTodayDateString();
+
     // service_idのリストを構築
-    const serviceIds = ids.map((id) => `like:${id}:total`);
+    const serviceIds = uniqueIds.map((id) => `like:${id}:total`);
+    const actionServiceIds = uniqueIds.map((id) => `like:${id}`);
 
     // D1はIN句のプレースホルダを動的に構築する必要がある
     const placeholders = serviceIds.map(() => "?").join(",");
-    const query = `SELECT service_id, total FROM likes WHERE service_id IN (${placeholders})`;
+    const actionPlaceholders = actionServiceIds.map(() => "?").join(",");
+    const totalsQuery = `SELECT service_id, total FROM likes WHERE service_id IN (${placeholders})`;
+    const likedQuery = `SELECT service_id, value FROM daily_actions WHERE service_id IN (${actionPlaceholders}) AND user_hash = ? AND date = ? AND action_type = ?`;
 
-    const result = await db
-      .prepare(query)
-      .bind(...serviceIds)
-      .all<{ service_id: string; total: number }>();
+    const [totalsResult, likedResult] = await Promise.all([
+      db
+        .prepare(totalsQuery)
+        .bind(...serviceIds)
+        .all<{ service_id: string; total: number }>(),
+      db
+        .prepare(likedQuery)
+        .bind(...actionServiceIds, userHash, today, "like")
+        .all<{ service_id: string; value: string }>(),
+    ]);
 
     // 結果をIDでマップ
-    const data: Record<string, { total: number }> = {};
-    for (const row of result.results || []) {
+    const data: Record<string, { id: string; total: number; liked: boolean }> = {};
+    for (const row of totalsResult.results || []) {
       // "like:xxx:total" から "xxx" を抽出
-      const id = row.service_id.replace(/^like:/, "").replace(/:total$/, "");
-      data[id] = { total: row.total };
+      const id = stripLikeTotalServiceId(row.service_id);
+      data[id] = { id, total: row.total, liked: false };
+    }
+
+    for (const row of likedResult.results || []) {
+      const id = stripLikeServiceId(row.service_id);
+      data[id] = { id, total: data[id]?.total ?? 0, liked: row.value === "liked" };
     }
 
     // リクエストされたが存在しないIDは0として含める
-    for (const id of ids) {
+    for (const id of uniqueIds) {
       if (!data[id]) {
-        data[id] = { total: 0 };
+        data[id] = { id, total: 0, liked: false };
       }
     }
 

--- a/apps/api/src/routes/visit.ts
+++ b/apps/api/src/routes/visit.ts
@@ -98,6 +98,16 @@ async function getCounterData(db: D1Database, id: string) {
   return { id, total, today, yesterday, week, month };
 }
 
+type CounterData = Awaited<ReturnType<typeof getCounterData>>;
+
+function stripCounterTotalServiceId(serviceId: string): string {
+  return serviceId.replace(/^counter:/, "").replace(/:total$/, "");
+}
+
+function stripCounterServiceId(serviceId: string): string {
+  return serviceId.replace(/^counter:/, "");
+}
+
 /** Verify owner token against DB */
 async function verifyOwnerToken(
   db: D1Database,
@@ -181,7 +191,7 @@ app.get("/", async (c) => {
           metadata.webhookUrl,
           "counter.increment",
           WebHookMessages.counter.increment(data.total),
-          { id, ...data }
+          data
         );
       }
     }
@@ -629,31 +639,63 @@ app.post("/", async (c) => {
       }
     }
 
+    const uniqueIds = [...new Set(ids)];
+
     // service_idのリストを構築
-    const serviceIds = ids.map((id) => `counter:${id}:total`);
+    const totalServiceIds = uniqueIds.map((id) => `counter:${id}:total`);
+    const dailyServiceIds = uniqueIds.map((id) => `counter:${id}`);
 
     // D1はIN句のプレースホルダを動的に構築する必要がある
-    const placeholders = serviceIds.map(() => "?").join(",");
-    const query = `SELECT service_id, total FROM counters WHERE service_id IN (${placeholders})`;
+    const totalPlaceholders = totalServiceIds.map(() => "?").join(",");
+    const dailyPlaceholders = dailyServiceIds.map(() => "?").join(",");
+    const totalsQuery = `SELECT service_id, total FROM counters WHERE service_id IN (${totalPlaceholders})`;
+    const dailyQuery = `SELECT service_id, date, count FROM counter_daily WHERE service_id IN (${dailyPlaceholders}) AND date >= ?`;
 
-    const result = await db
-      .prepare(query)
-      .bind(...serviceIds)
-      .all<{ service_id: string; total: number }>();
+    const today = getTodayDateString();
+    const yesterday = getYesterdayDateString();
+    const weekStart = getDateRange(7).at(-1) || today;
+    const monthStart = getDateRange(30).at(-1) || today;
+
+    const [totalsResult, dailyResult] = await Promise.all([
+      db
+        .prepare(totalsQuery)
+        .bind(...totalServiceIds)
+        .all<{ service_id: string; total: number }>(),
+      db
+        .prepare(dailyQuery)
+        .bind(...dailyServiceIds, monthStart)
+        .all<{ service_id: string; date: string; count: number }>(),
+    ]);
 
     // 結果をIDでマップ
-    const data: Record<string, { total: number }> = {};
-    for (const row of result.results || []) {
-      // "counter:xxx:total" から "xxx" を抽出
-      const id = row.service_id.replace(/^counter:/, "").replace(/:total$/, "");
-      data[id] = { total: row.total };
+    const data: Record<string, CounterData> = {};
+    for (const id of uniqueIds) {
+      data[id] = { id, total: 0, today: 0, yesterday: 0, week: 0, month: 0 };
     }
 
-    // リクエストされたが存在しないIDは0として含める
-    for (const id of ids) {
-      if (!data[id]) {
-        data[id] = { total: 0 };
+    for (const row of totalsResult.results || []) {
+      // "counter:xxx:total" から "xxx" を抽出
+      const id = stripCounterTotalServiceId(row.service_id);
+      data[id] = {
+        ...(data[id] || { id, today: 0, yesterday: 0, week: 0, month: 0 }),
+        total: row.total,
+      };
+    }
+
+    for (const row of dailyResult.results || []) {
+      const id = stripCounterServiceId(row.service_id);
+      const item = data[id] || { id, total: 0, today: 0, yesterday: 0, week: 0, month: 0 };
+      if (row.date === today) {
+        item.today += row.count;
       }
+      if (row.date === yesterday) {
+        item.yesterday += row.count;
+      }
+      if (row.date >= weekStart) {
+        item.week += row.count;
+      }
+      item.month += row.count;
+      data[id] = item;
     }
 
     return c.json({ success: true, data });

--- a/apps/web/public/components/like.js
+++ b/apps/web/public/components/like.js
@@ -150,7 +150,7 @@ class NostalgicLike extends HTMLElement {
         }
 
         for (const id of chunk) {
-          const data = responseData.data?.[id] || { total: 0, liked: false };
+          const data = responseData.data?.[id] || { id, total: 0, liked: false };
           NostalgicLike.setCachedData(baseUrl, id, data);
           for (const resolver of queue.resolvers.get(id) || []) {
             resolver.resolve(data);

--- a/apps/web/public/components/like.js
+++ b/apps/web/public/components/like.js
@@ -28,6 +28,12 @@ function getLikeTranslations(element) {
 class NostalgicLike extends HTMLElement {
   // APIのベースURL
   static apiBaseUrl = "https://api.nostalgic.llll-ll.com";
+  static batchDelayMs = 16;
+  static cacheTtlMs = 5000;
+  static maxBatchSize = 1000;
+  static dataCache = new Map();
+  static batchQueues = new Map();
+  static instances = new Map();
 
   constructor() {
     super();
@@ -37,7 +43,155 @@ class NostalgicLike extends HTMLElement {
   }
 
   static get observedAttributes() {
-    return ["id", "theme", "icon", "format", "lang"];
+    return ["id", "theme", "icon", "format", "lang", "api-base"];
+  }
+
+  static cacheKey(baseUrl, id) {
+    return `${baseUrl}|${id}`;
+  }
+
+  static getCachedData(key) {
+    const cached = NostalgicLike.dataCache.get(key);
+    if (!cached || cached.expiresAt <= Date.now()) {
+      NostalgicLike.dataCache.delete(key);
+      return null;
+    }
+    return cached.data;
+  }
+
+  static setCachedData(baseUrl, id, data) {
+    const key = NostalgicLike.cacheKey(baseUrl, id);
+    NostalgicLike.dataCache.set(key, {
+      data,
+      expiresAt: Date.now() + NostalgicLike.cacheTtlMs,
+    });
+    NostalgicLike.notifyInstances(key, data);
+  }
+
+  static registerInstance(instance, baseUrl, id) {
+    const key = NostalgicLike.cacheKey(baseUrl, id);
+    instance.likeKey = key;
+    if (!NostalgicLike.instances.has(key)) {
+      NostalgicLike.instances.set(key, new Set());
+    }
+    NostalgicLike.instances.get(key).add(instance);
+  }
+
+  static unregisterInstance(instance) {
+    if (!instance.likeKey) return;
+    const set = NostalgicLike.instances.get(instance.likeKey);
+    if (set) {
+      set.delete(instance);
+      if (set.size === 0) {
+        NostalgicLike.instances.delete(instance.likeKey);
+      }
+    }
+    instance.likeKey = null;
+  }
+
+  static notifyInstances(key, data) {
+    const set = NostalgicLike.instances.get(key);
+    if (!set) return;
+    for (const instance of set) {
+      instance.likeData = data;
+      instance.isLoading = false;
+      instance.render();
+    }
+  }
+
+  static requestLikeData(baseUrl, id) {
+    const key = NostalgicLike.cacheKey(baseUrl, id);
+    const cached = NostalgicLike.getCachedData(key);
+    if (cached) {
+      return Promise.resolve(cached);
+    }
+
+    return new Promise((resolve, reject) => {
+      let queue = NostalgicLike.batchQueues.get(baseUrl);
+      if (!queue) {
+        queue = { ids: new Set(), resolvers: new Map(), timer: null };
+        NostalgicLike.batchQueues.set(baseUrl, queue);
+      }
+
+      queue.ids.add(id);
+      if (!queue.resolvers.has(id)) {
+        queue.resolvers.set(id, []);
+      }
+      queue.resolvers.get(id).push({ resolve, reject });
+
+      if (!queue.timer) {
+        queue.timer = setTimeout(() => {
+          NostalgicLike.flushBatch(baseUrl);
+        }, NostalgicLike.batchDelayMs);
+      }
+    });
+  }
+
+  static async flushBatch(baseUrl) {
+    const queue = NostalgicLike.batchQueues.get(baseUrl);
+    if (!queue) return;
+    NostalgicLike.batchQueues.delete(baseUrl);
+
+    const ids = [...queue.ids];
+    for (let i = 0; i < ids.length; i += NostalgicLike.maxBatchSize) {
+      const chunk = ids.slice(i, i + NostalgicLike.maxBatchSize);
+      try {
+        const response = await fetch(`${baseUrl}/like?action=batchGet`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ ids: chunk }),
+        });
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
+        }
+        const responseData = await response.json();
+        if (!responseData.success) {
+          throw new Error(responseData.error || "API returned an error");
+        }
+
+        for (const id of chunk) {
+          const data = responseData.data?.[id] || { total: 0, liked: false };
+          NostalgicLike.setCachedData(baseUrl, id, data);
+          for (const resolver of queue.resolvers.get(id) || []) {
+            resolver.resolve(data);
+          }
+        }
+      } catch (error) {
+        for (const id of chunk) {
+          for (const resolver of queue.resolvers.get(id) || []) {
+            resolver.reject(error);
+          }
+        }
+      }
+    }
+  }
+
+  static generateLikeSVG(count) {
+    const label = "♥ likes";
+    const labelWidth = 50;
+    const valueWidth = Math.max(String(count).length * 7 + 10, 30);
+    const totalWidth = labelWidth + valueWidth;
+
+    return `<svg xmlns="http://www.w3.org/2000/svg" width="${totalWidth}" height="20">
+  <linearGradient id="smooth" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <clipPath id="round">
+    <rect width="${totalWidth}" height="20" rx="3" fill="#fff"/>
+  </clipPath>
+  <g clip-path="url(#round)">
+    <rect width="${labelWidth}" height="20" fill="#555"/>
+    <rect x="${labelWidth}" width="${valueWidth}" height="20" fill="#e91e63"/>
+    <rect width="${totalWidth}" height="20" fill="url(#smooth)"/>
+  </g>
+  <g text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
+    <text x="${labelWidth / 2}" y="15" fill="#010101" fill-opacity=".3">${label}</text>
+    <text x="${labelWidth / 2}" y="14" fill="#fff">${label}</text>
+    <text x="${labelWidth + valueWidth / 2}" y="15" fill="#010101" fill-opacity=".3">${count}</text>
+    <text x="${labelWidth + valueWidth / 2}" y="14" fill="#fff">${count}</text>
+  </g>
+</svg>`;
   }
 
   get t() {
@@ -85,9 +239,18 @@ class NostalgicLike extends HTMLElement {
     this.loadLikeData();
   }
 
-  attributeChangedCallback() {
+  disconnectedCallback() {
+    NostalgicLike.unregisterInstance(this);
+  }
+
+  attributeChangedCallback(name, oldValue, newValue) {
     if (this.isConnected) {
-      this.loadLikeData();
+      if (name === "id" || name === "api-base") {
+        NostalgicLike.unregisterInstance(this);
+        this.loadLikeData();
+      } else {
+        this.render();
+      }
     }
   }
 
@@ -102,19 +265,8 @@ class NostalgicLike extends HTMLElement {
 
     try {
       const baseUrl = this.safeGetAttribute("api-base") || NostalgicLike.apiBaseUrl;
-      const apiUrl = `${baseUrl}/like?action=get&id=${encodeURIComponent(id)}`;
-
-      const response = await fetch(apiUrl);
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}`);
-      }
-
-      const responseData = await response.json();
-      if (responseData.success) {
-        this.likeData = responseData.data;
-      } else {
-        throw new Error(responseData.error || "API returned an error");
-      }
+      NostalgicLike.registerInstance(this, baseUrl, id);
+      this.likeData = await NostalgicLike.requestLikeData(baseUrl, id);
     } catch (error) {
       console.error("nostalgic-like: Failed to load data:", error);
       this.likeData = { total: 0, liked: false };
@@ -143,6 +295,7 @@ class NostalgicLike extends HTMLElement {
       const responseData = await response.json();
       if (responseData.success) {
         this.likeData = responseData.data;
+        NostalgicLike.setCachedData(baseUrl, id, responseData.data);
       } else {
         throw new Error(responseData.error || "API returned an error");
       }
@@ -179,9 +332,7 @@ class NostalgicLike extends HTMLElement {
 
     // SVG画像形式の場合
     if (format === "image") {
-      const baseUrl = this.safeGetAttribute("api-base") || NostalgicLike.apiBaseUrl;
-      const id = this.safeGetAttribute("id");
-      const apiUrl = `${baseUrl}/like?action=get&id=${encodeURIComponent(id)}${theme ? `&theme=${theme}` : ""}&format=image`;
+      const total = this.likeData ? this.likeData.total : 0;
 
       this.shadowRoot.innerHTML = `
         <style>
@@ -194,7 +345,7 @@ class NostalgicLike extends HTMLElement {
             height: auto;
           }
         </style>
-        <img src="${apiUrl}" alt="like count" loading="lazy" />
+        ${NostalgicLike.generateLikeSVG(total)}
       `;
       return;
     }

--- a/apps/web/public/components/visit.js
+++ b/apps/web/public/components/visit.js
@@ -28,7 +28,8 @@ function getCounterTranslations(element) {
 class NostalgicCounter extends HTMLElement {
   // ページ内でカウント済みのIDを記録（同じIDは1回のみカウント）
   static counted = new Set();
-  // カウントアップ後の最新データを保存
+  // カウントアップ後の最新データを保存。TTL は持たず、ページ存続中は保持し続ける
+  // （「1ページ1回だけカウント」の意図どおり、再 render 時に同じ最新値を即表示するため）。
   static latestCounts = new Map();
   static countPromises = new Map();
   static batchDelayMs = 16;
@@ -142,6 +143,18 @@ class NostalgicCounter extends HTMLElement {
     }
   }
 
+  // ピクセルアート系テーマ。これらは API が画像を焼き込んで返すため、
+  // クライアント直描画ではなくサーバー <img> にフォールバックする。
+  // apps/api/src/routes/visit.ts の IMAGE_THEMES と必ず同期させること。
+  static IMAGE_THEME_NAMES = ["mahjong", "segment", "nixie", "dots_f"];
+
+  static isImageTheme(theme) {
+    return NostalgicCounter.IMAGE_THEME_NAMES.includes(theme);
+  }
+
+  // 通常色テーマの SVG 生成。見た目の定数（テーマ色・寸法・フォント）は
+  // apps/api/src/routes/visit.ts の generateCounterSVG / generateShieldsBadgeSVG の
+  // 逐語コピー。どちらか片方を変えると表示が割れるため、必ず両方を同期させること。
   static generateCounterSVG(value, theme) {
     if (theme === "github") {
       return NostalgicCounter.generateShieldsBadgeSVG("visitors", value, "#4c1");
@@ -428,10 +441,10 @@ class NostalgicCounter extends HTMLElement {
             this.shadowRoot.innerHTML = `${textStyle}<span>${this.t.error}</span>`;
           });
       }
-    } else {
-      // 画像形式の場合（デフォルト）。<img>直叩きではなく共有済みデータから描画する。
-      const value = hasLatestData ? latestData[type] : 0;
-      const displayValue = digits ? String(value).padStart(Number(digits), "0") : String(value);
+    } else if (NostalgicCounter.isImageTheme(theme)) {
+      // ピクセルアート系テーマは API が画像を焼き込んで返すため、サーバー <img> に委ねる。
+      // 値も URL 経由でサーバーが算出するため batchGet 集約には乗せない。
+      const apiUrl = `${baseUrl}/visit?action=get&id=${encodeURIComponent(id)}${type ? `&type=${type}` : ""}${theme ? `&theme=${theme}` : ""}${digits ? `&digits=${digits}` : ""}&format=image`;
       this.shadowRoot.innerHTML = `
         <style>
           :host {
@@ -444,6 +457,18 @@ class NostalgicCounter extends HTMLElement {
             image-rendering: crisp-edges;
             max-width: 100%;
             height: auto;
+          }
+        </style>
+        <img src="${apiUrl}" alt="${type} counter" loading="lazy" />
+      `;
+    } else {
+      // 通常の色テーマは <img>直叩きではなく共有済みデータからクライアント描画する。
+      const value = hasLatestData ? latestData[type] : 0;
+      const displayValue = digits ? String(value).padStart(Number(digits), "0") : String(value);
+      this.shadowRoot.innerHTML = `
+        <style>
+          :host {
+            display: inline-block;
           }
         </style>
         ${NostalgicCounter.generateCounterSVG(displayValue, theme)}

--- a/apps/web/public/components/visit.js
+++ b/apps/web/public/components/visit.js
@@ -30,6 +30,12 @@ class NostalgicCounter extends HTMLElement {
   static counted = new Set();
   // カウントアップ後の最新データを保存
   static latestCounts = new Map();
+  static countPromises = new Map();
+  static batchDelayMs = 16;
+  static cacheTtlMs = 5000;
+  static maxBatchSize = 1000;
+  static readCache = new Map();
+  static readQueues = new Map();
   // APIのベースURL
   static apiBaseUrl = "https://api.nostalgic.llll-ll.com";
 
@@ -39,7 +45,152 @@ class NostalgicCounter extends HTMLElement {
   }
 
   static get observedAttributes() {
-    return ["id", "type", "theme", "digits", "lang"];
+    return ["id", "type", "theme", "digits", "format", "lang", "api-base"];
+  }
+
+  static cacheKey(baseUrl, id) {
+    return `${baseUrl}|${id}`;
+  }
+
+  static getCachedData(key) {
+    const cached = NostalgicCounter.readCache.get(key);
+    if (!cached || cached.expiresAt <= Date.now()) {
+      NostalgicCounter.readCache.delete(key);
+      return null;
+    }
+    return cached.data;
+  }
+
+  static setCachedData(baseUrl, id, data) {
+    NostalgicCounter.latestCounts.set(id, data);
+    NostalgicCounter.readCache.set(NostalgicCounter.cacheKey(baseUrl, id), {
+      data,
+      expiresAt: Date.now() + NostalgicCounter.cacheTtlMs,
+    });
+  }
+
+  static requestCounterData(baseUrl, id) {
+    const cached = NostalgicCounter.getCachedData(NostalgicCounter.cacheKey(baseUrl, id));
+    if (cached) {
+      return Promise.resolve(cached);
+    }
+
+    return new Promise((resolve, reject) => {
+      let queue = NostalgicCounter.readQueues.get(baseUrl);
+      if (!queue) {
+        queue = { ids: new Set(), resolvers: new Map(), timer: null };
+        NostalgicCounter.readQueues.set(baseUrl, queue);
+      }
+
+      queue.ids.add(id);
+      if (!queue.resolvers.has(id)) {
+        queue.resolvers.set(id, []);
+      }
+      queue.resolvers.get(id).push({ resolve, reject });
+
+      if (!queue.timer) {
+        queue.timer = setTimeout(() => {
+          NostalgicCounter.flushReadBatch(baseUrl);
+        }, NostalgicCounter.batchDelayMs);
+      }
+    });
+  }
+
+  static async flushReadBatch(baseUrl) {
+    const queue = NostalgicCounter.readQueues.get(baseUrl);
+    if (!queue) return;
+    NostalgicCounter.readQueues.delete(baseUrl);
+
+    const ids = [...queue.ids];
+    for (let i = 0; i < ids.length; i += NostalgicCounter.maxBatchSize) {
+      const chunk = ids.slice(i, i + NostalgicCounter.maxBatchSize);
+      try {
+        const response = await fetch(`${baseUrl}/visit?action=batchGet`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ ids: chunk }),
+        });
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
+        }
+        const responseData = await response.json();
+        if (!responseData.success) {
+          throw new Error(responseData.error || "API returned an error");
+        }
+
+        for (const id of chunk) {
+          const data = responseData.data?.[id] || {
+            id,
+            total: 0,
+            today: 0,
+            yesterday: 0,
+            week: 0,
+            month: 0,
+          };
+          NostalgicCounter.setCachedData(baseUrl, id, data);
+          for (const resolver of queue.resolvers.get(id) || []) {
+            resolver.resolve(data);
+          }
+        }
+      } catch (error) {
+        for (const id of chunk) {
+          for (const resolver of queue.resolvers.get(id) || []) {
+            resolver.reject(error);
+          }
+        }
+      }
+    }
+  }
+
+  static generateCounterSVG(value, theme) {
+    if (theme === "github") {
+      return NostalgicCounter.generateShieldsBadgeSVG("visitors", value, "#4c1");
+    }
+
+    const themes = {
+      light: { bg: "#ffffff", text: "#333333", border: "#cccccc" },
+      dark: { bg: "#1a1a2e", text: "#eaeaea", border: "#4a4a6a" },
+      retro: { bg: "#000000", text: "#00ff00", border: "#00ff00" },
+      kawaii: { bg: "#e0f7fa", text: "#ff69b4", border: "#ff69b4" },
+      mom: { bg: "#98fb98", text: "#2d4a2b", border: "#2d4a2b" },
+      final: { bg: "#0000ff", text: "#ffffff", border: "#ffffff" },
+    };
+
+    const t = themes[theme] || themes.dark;
+    const width = Math.max(60, String(value).length * 12 + 20);
+
+    return `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="28">
+  <rect width="100%" height="100%" fill="${t.bg}" stroke="${t.border}" stroke-width="1"/>
+  <text x="50%" y="50%" dy="0.35em" text-anchor="middle"
+        fill="${t.text}" font-family="'BIZ UDGothic', monospace" font-size="14" font-weight="bold">${value}</text>
+</svg>`;
+  }
+
+  static generateShieldsBadgeSVG(label, value, valueColor) {
+    const labelWidth = label.length * 6 + 6;
+    const valueWidth = Math.max(String(value).length * 7 + 10, 30);
+    const totalWidth = labelWidth + valueWidth;
+
+    return `<svg xmlns="http://www.w3.org/2000/svg" width="${totalWidth}" height="20">
+  <linearGradient id="smooth" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <clipPath id="round">
+    <rect width="${totalWidth}" height="20" rx="3" fill="#fff"/>
+  </clipPath>
+  <g clip-path="url(#round)">
+    <rect width="${labelWidth}" height="20" fill="#555"/>
+    <rect x="${labelWidth}" width="${valueWidth}" height="20" fill="${valueColor}"/>
+    <rect width="${totalWidth}" height="20" fill="url(#smooth)"/>
+  </g>
+  <g text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
+    <text x="${labelWidth / 2}" y="15" fill="#010101" fill-opacity=".3">${label}</text>
+    <text x="${labelWidth / 2}" y="14" fill="#fff">${label}</text>
+    <text x="${labelWidth + valueWidth / 2}" y="15" fill="#010101" fill-opacity=".3">${value}</text>
+    <text x="${labelWidth + valueWidth / 2}" y="14" fill="#fff">${value}</text>
+  </g>
+</svg>`;
   }
 
   get t() {
@@ -91,12 +242,16 @@ class NostalgicCounter extends HTMLElement {
     this.countUpAndRender();
   }
 
-  attributeChangedCallback() {
+  attributeChangedCallback(name) {
     // 初回接続前は何もしない（connectedCallbackで処理）
     if (!this.isConnected) {
       return;
     }
-    this.render();
+    if (name === "id" || name === "api-base") {
+      this.countUpAndRender();
+    } else {
+      this.render();
+    }
   }
 
   async countUpAndRender() {
@@ -109,12 +264,6 @@ class NostalgicCounter extends HTMLElement {
     // フォーマットをチェックして初期表示を設定
     const format = this.safeGetAttribute("format");
 
-    // 既にカウント済みの場合は即座にレンダリング
-    if (NostalgicCounter.counted.has(id)) {
-      this.render();
-      return;
-    }
-
     // テキスト形式の場合は先に初期値を表示
     if (format === "text") {
       this.renderInitialText();
@@ -122,6 +271,7 @@ class NostalgicCounter extends HTMLElement {
 
     // カウントアップして結果を待つ
     await this.countUp();
+    await this.ensureCounterData();
     this.render();
   }
 
@@ -135,12 +285,12 @@ class NostalgicCounter extends HTMLElement {
 
     // 同じIDは1回のみカウント（ページ内重複防止）
     if (NostalgicCounter.counted.has(id)) {
-      return;
+      return NostalgicCounter.countPromises.get(id);
     }
 
     NostalgicCounter.counted.add(id);
 
-    try {
+    const promise = (async () => {
       const baseUrl = this.getAttribute("api-base") || NostalgicCounter.apiBaseUrl;
       const countUrl = `${baseUrl}/visit?action=increment&id=${encodeURIComponent(id)}`;
       const response = await fetch(countUrl);
@@ -156,13 +306,35 @@ class NostalgicCounter extends HTMLElement {
         const result = await response.json();
         // カウントアップ後の値で表示を更新
         if (result.success && result.data) {
-          NostalgicCounter.latestCounts.set(id, result.data);
+          NostalgicCounter.setCachedData(baseUrl, id, result.data);
         } else {
-          NostalgicCounter.latestCounts.set(id, result);
+          NostalgicCounter.setCachedData(baseUrl, id, result);
         }
       }
+    })();
+
+    NostalgicCounter.countPromises.set(id, promise);
+
+    try {
+      await promise;
     } catch (error) {
       console.error("nostalgic-counter: Count failed:", error);
+    }
+  }
+
+  async ensureCounterData() {
+    const id = this.safeGetAttribute("id");
+    if (!id) return;
+
+    const baseUrl = this.getAttribute("api-base") || NostalgicCounter.apiBaseUrl;
+    if (NostalgicCounter.latestCounts.has(id)) {
+      return;
+    }
+
+    try {
+      await NostalgicCounter.requestCounterData(baseUrl, id);
+    } catch (error) {
+      console.error("nostalgic-counter: Failed to load data:", error);
     }
   }
 
@@ -189,7 +361,7 @@ class NostalgicCounter extends HTMLElement {
 
   render() {
     const id = this.safeGetAttribute("id");
-    const type = this.safeGetAttribute("type");
+    const type = this.safeGetAttribute("type") || "total";
     const theme = this.safeGetAttribute("theme");
     const digits = this.safeGetAttribute("digits");
     const format = this.safeGetAttribute("format");
@@ -216,8 +388,6 @@ class NostalgicCounter extends HTMLElement {
 
     const baseUrl = this.getAttribute("api-base") || NostalgicCounter.apiBaseUrl;
     const effectiveFormat = format || "text";
-    const apiUrl = `${baseUrl}/visit?action=get&id=${encodeURIComponent(id)}${type ? `&type=${type}` : ""}${theme ? `&theme=${theme}` : ""}${digits ? `&digits=${digits}` : ""}&format=${effectiveFormat}`;
-
     // カウントアップ後の最新データがあれば使用
     const latestData = NostalgicCounter.latestCounts.get(id);
     const hasLatestData = latestData && latestData[type] !== undefined;
@@ -248,26 +418,20 @@ class NostalgicCounter extends HTMLElement {
         // ローディング中は0を桁数分表示
         this.shadowRoot.innerHTML = `${textStyle}<span>${formatValue(0)}</span>`;
 
-        // 値を非同期で取得（action=get&format=textを使用）
-        fetch(
-          `${baseUrl}/visit?action=get&id=${encodeURIComponent(id)}&type=${type}&format=text${digits ? `&digits=${digits}` : ""}`
-        )
-          .then((response) => {
-            if (!response.ok) {
-              throw new Error(`HTTP ${response.status}`);
-            }
-            return response.text(); // テキスト形式なのでtextで取得
-          })
+        // 値を非同期で取得（ページ全体でbatchGetに集約）
+        NostalgicCounter.requestCounterData(baseUrl, id)
           .then((data) => {
-            // すでに桁数がパディング済みの文字列なのでそのまま表示
-            this.shadowRoot.innerHTML = `${textStyle}<span>${data}</span>`;
+            const value = data[type] ?? data.total;
+            this.shadowRoot.innerHTML = `${textStyle}<span>${formatValue(value)}</span>`;
           })
           .catch((error) => {
             this.shadowRoot.innerHTML = `${textStyle}<span>${this.t.error}</span>`;
           });
       }
     } else {
-      // 画像形式の場合（デフォルト）
+      // 画像形式の場合（デフォルト）。<img>直叩きではなく共有済みデータから描画する。
+      const value = hasLatestData ? latestData[type] : 0;
+      const displayValue = digits ? String(value).padStart(Number(digits), "0") : String(value);
       this.shadowRoot.innerHTML = `
         <style>
           :host {
@@ -282,8 +446,14 @@ class NostalgicCounter extends HTMLElement {
             height: auto;
           }
         </style>
-        <img src="${apiUrl}" alt="${type} counter" loading="lazy" />
+        ${NostalgicCounter.generateCounterSVG(displayValue, theme)}
       `;
+
+      if (!hasLatestData) {
+        NostalgicCounter.requestCounterData(baseUrl, id)
+          .then(() => this.render())
+          .catch(() => {});
+      }
     }
   }
 }

--- a/docs/design/system-architecture.md
+++ b/docs/design/system-architecture.md
@@ -1,0 +1,84 @@
+# Nostalgic System Architecture
+
+最終更新: 2026-06-01
+
+この文書は Nostalgic の実装構造の正本である。利用者向け API 仕様は
+`docs/user-guide/`、見た目の設計は `DESIGN.md` と
+`docs/development/design-philosophy.md` を参照する。
+
+## 目的
+
+Nostalgic は、カウンター・いいね・ランキング・BBS・招き猫を、静的サイトや
+README に埋め込める Web ツールとして提供する。API は Cloudflare Workers +
+D1、管理・デモ UI は React、第三者サイトへの設置面は Web Components と
+画像 URL で構成する。
+
+## 実行単位
+
+| 層             | パス                              | 責務                                           |
+| -------------- | --------------------------------- | ---------------------------------------------- |
+| API Worker     | `apps/api/src/index.ts`           | CORS、rate limit、各サービス route の mount    |
+| API routes     | `apps/api/src/routes/*.ts`        | サービス別の create/get/update/delete/mutation |
+| API core       | `apps/api/src/lib/core/`          | token、ID、日付、hash、webhook、共通型         |
+| D1 schema      | `apps/api/schema.sql`             | 永続化スキーマ                                 |
+| Web app        | `apps/web/src/`                   | Nostalgic 本体サイト、デモ、API 操作用 UI      |
+| Web Components | `apps/web/public/components/*.js` | 第三者サイトに貼る埋め込み部品                 |
+
+`apps/web/dist/` はビルド成果物であり、設計判断の正本にしない。
+
+## サービス ID と永続化
+
+サービスは `services.id` に `type:publicId` の形で登録する。
+サービスごとの実データは用途別テーブルに分ける。
+
+| サービス | メタデータ                    | 実データ                                                          | ユーザー状態                                         |
+| -------- | ----------------------------- | ----------------------------------------------------------------- | ---------------------------------------------------- |
+| Counter  | `services(id='counter:{id}')` | `counters('counter:{id}:total')`, `counter_daily('counter:{id}')` | `daily_actions('counter:{id}', action_type='visit')` |
+| Like     | `services(id='like:{id}')`    | `likes('like:{id}:total')`                                        | `daily_actions('like:{id}', action_type='like')`     |
+| Ranking  | `services(id='ranking:{id}')` | `ranking_scores('ranking:{id}')`                                  | `daily_actions` for submit identity                  |
+| BBS      | `services(id='bbs:{id}')`     | `bbs_messages('bbs:{id}')`                                        | message `user_hash`                                  |
+| Yokoso   | `services(id='yokoso:{id}')`  | `services.metadata`                                               | none                                                 |
+
+`url_mappings` は owner-mode lookup 用であり、公開埋め込みは public ID を使う。
+
+## 読み取りと書き込みの境界
+
+Nostalgic は「表示」と「イベント」を分ける。
+
+- `get`, `batchGet`, `sumByPrefix`: 表示用の読み取り
+- `create`, `update`, `delete`, `batchCreate`: 管理操作
+- `increment`, `toggle`, `submit`, `post`, `remove`, `clear`: ユーザーイベントまたは状態変更
+
+Counter の `increment` は閲覧イベントであり、表示取得ではない。複数ページや一覧の
+都合で `increment` をまとめる API は作らない。
+
+## Web Components の境界
+
+`apps/web/public/components/*.js` は、React アプリとは独立して第三者ページで動く。
+
+- Shadow DOM 内で完結する
+- 設置者がビルドツールを持たない前提で素の JavaScript にする
+- `id` がなければエラー表示し、ページ全体を壊さない
+- ビジネスルールの検証は API に任せる
+- 同じページ内の重複通信は JS 側で抑制する
+
+React 側の `apps/web/src/config/services/*Steps.tsx` は操作 UI の定義データである。
+Web Components の runtime state と混ぜない。
+
+## CORS と HTTP method
+
+`apps/api/src/index.ts` で CORS と rate limit をまとめて扱う。
+
+- `GET` / `HEAD` / `OPTIONS` / `batchGet`: 第三者埋め込みのため `origin: "*"`
+- mutation や token を含む操作: POST body を使い、許可 origin を絞る
+- `batchGet` は読み取りだが、大量 ID を扱うため POST body を使う
+
+React 側の `apps/web/src/utils/apiHelpers.ts` と `apps/web/src/hooks/useFetchApi.ts`
+は、token や POST action を URL から body に移す責務を持つ。
+
+## 現在の設計上の注意点
+
+- `visit.ts` / `like.ts` には `batchGet` がある。Web Components はこれを内部利用して読み取りを集約する
+- `like` の `batchGet` は `id` / `total` / 現在ユーザーの `liked` を返す正規の一覧取得 API とする
+- `visit` の `batchGet` は `id` / `total` / `today` / `yesterday` / `week` / `month` を返す正規の一覧取得 API とする
+- `ranking` / `bbs` / `yokoso` には batch API がない。まず同一 ID の in-flight dedupe/cache で足りるか判断する

--- a/docs/guidelines/implementation.md
+++ b/docs/guidelines/implementation.md
@@ -1,0 +1,111 @@
+# Implementation Guidelines
+
+最終更新: 2026-06-01
+
+この文書は Nostalgic の実装規約である。構造の説明は
+`docs/design/system-architecture.md`、公開 API の説明は `docs/user-guide/` を参照する。
+
+## 1. docs を正本にする
+
+API の公開仕様を変えるときは `docs/user-guide/` を更新する。実装構造や責務境界を
+変えるときは `docs/design/system-architecture.md` を更新する。Web Components の
+防御的な書き方は `docs/development/webcomponents-defensive-programming.md` を
+正本にする。
+
+## 2. 定義データと実行時状態を分ける
+
+不変の定義と実行時に変わる状態を同じモジュールに混ぜない。
+
+| 種別         | 例                                        | 規約                                                     |
+| ------------ | ----------------------------------------- | -------------------------------------------------------- |
+| 定義データ   | `apps/web/src/config/services/*Steps.tsx` | UI 手順と field 定義だけを置く                           |
+| 定義データ   | `apps/web/src/config/embedConfigs.ts`     | 埋め込みコードの定義だけを置く                           |
+| 定義データ   | `apps/api/src/lib/core/constants.ts`      | service 共通の定数だけを置く                             |
+| 実行時状態   | React `useState`                          | ページコンポーネントに閉じる                             |
+| 実行時状態   | Web Component instance fields             | component instance に閉じる                              |
+| 共有 runtime | Web Component static cache / queue        | 取得重複排除など、ページ全体で共有する必要があるものだけ |
+
+新しい設定を追加するときは、まず定義データの型と置き場を決め、その後に処理をつなぐ。
+
+## 3. 読み取りとイベントを分ける
+
+読み取りは集約してよい。イベントは勝手に集約しない。
+
+- `get` / `batchGet` / `sumByPrefix` は表示用の読み取り
+- Counter `increment` は閲覧イベント
+- Like `toggle` はユーザー操作イベント
+- Ranking `submit` と BBS `post` はユーザー投稿イベント
+
+`batchIncrement` は作らない。Counter の一覧表示やデモ表示では `batchGet` を使い、
+個別ページや実際の閲覧地点だけで `increment` を単発実行する。
+
+## 4. Web Components は設置者に batching を意識させない
+
+第三者サイトの設置コードは独立したタグのままでよい。
+
+```html
+<script src="https://nostalgic.llll-ll.com/components/like.js"></script>
+<nostalgic-like id="example" theme="light" icon="heart"></nostalgic-like>
+<nostalgic-like id="example" theme="dark" icon="star"></nostalgic-like>
+```
+
+内部実装はページ全体で読み取りを集約する。
+
+- service 種別ごとに queue を持つ
+- 同一 ID は重複排除する
+- theme / icon / format / 見た目グループで通信を分けない
+- API 上限を超えるときだけ chunk する
+- 短い待ち時間で同時 mount を同じ便に乗せる
+- 短い TTL cache で同一ページ内の再取得を抑える
+
+## 5. API route は service 単位に閉じる
+
+`apps/api/src/routes/{service}.ts` は、その service の公開 action を完結して扱う。
+共通化する場合は `apps/api/src/lib/core/` に置く。
+
+route を増やすときは次を揃える。
+
+- GET public mode と POST owner/mutation mode の境界
+- token を query string に残さない
+- D1 の `service_id` 命名
+- `docs/user-guide/services/{service}.md`
+- デモ UI の `apps/web/src/config/services/{service}Steps.tsx`
+- Web Component がある場合は `apps/web/public/components/{service}.js`
+
+## 6. D1 では ID 形式を先に決める
+
+テーブルごとの `service_id` 形式を曖昧にしない。
+
+- service metadata: `{type}:{id}`
+- counter total: `counter:{id}:total`
+- counter daily: `counter:{id}`
+- like total: `like:{id}:total`
+- like user state: `like:{id}`
+
+`batchGet` などで ID を戻すときは、prefix/suffix の除去規則をテスト可能な小さな関数に
+切り出す。`batchGet` は古い最小レスポンスに合わせず、各 service の `get` と同じ意味を
+持つ正規データを返す。
+
+## 7. Web Components の防御はクラッシュ防止に限定する
+
+Web Components 側で過度な validation をしない。ユーザー入力の妥当性、文字数制限、
+権限、存在確認は API の責務である。JS 側では DOM 要素の存在確認、`id` 欠落時の
+エラー表示、network error 時の fallback だけを行う。
+
+## 8. 画像 URL と Web Component を混同しない
+
+README や Markdown 用の画像 URL は `<img>` として直接 API を叩く前提でよい。
+通常の Web ページ向け Web Components は JS が取得を制御できるので、同一ページ内の
+通信を dedupe/cache する。両者を同じ実装制約で扱わない。
+
+## 9. 検証
+
+変更の種類ごとに最低限の確認を行う。
+
+- API 変更: `pnpm --filter @nostalgic/api exec tsc --noEmit`
+- Web app / React 変更: `pnpm --filter @nostalgic/web build`
+- repo 全体の静的確認: `pnpm lint`
+- Web Components の通信制御: ブラウザで Network 件数を確認するか、fetch mock で同一 ID の呼び出し数を確認する
+
+Cloudflare Workers / D1 の本番挙動に関わる変更は、local build だけで完了扱いにしない。
+可能なら `wrangler dev` か staging 相当で action ごとの実リクエストを確認する。

--- a/docs/guidelines/self-review-prompt.md
+++ b/docs/guidelines/self-review-prompt.md
@@ -1,0 +1,33 @@
+# Self Review Prompt
+
+Nostalgic の実装後レビューでは、次を順に確認する。
+
+1. 仕様と docs
+   - 公開 API を変えたなら `docs/user-guide/` が更新されているか
+   - 責務境界を変えたなら `docs/design/system-architecture.md` が更新されているか
+   - Web Components の防御方針から外れていないか
+
+2. 読み取りとイベント
+   - `get` / `batchGet` と `increment` / `toggle` / `submit` / `post` が混ざっていないか
+   - Counter の一覧表示で `increment` していないか
+   - `batchIncrement` 相当の挙動を作っていないか
+
+3. 定義データと状態
+   - `apps/web/src/config/services/*Steps.tsx` に runtime state が入っていないか
+   - Web Components の static state はページ全体で共有すべき cache/queue だけか
+   - API route に UI 固有の都合が漏れていないか
+
+4. D1 と ID
+   - `service_id` の prefix/suffix が既存規則と一致しているか
+   - batch response で public ID を壊していないか
+   - user hash / daily action の粒度が service と action に合っているか
+
+5. 埋め込み互換性
+   - 既存タグがそのまま動くか
+   - Markdown/README 用の画像 URL を壊していないか
+   - 第三者 origin の CORS を壊していないか
+
+6. 検証
+   - TypeScript/build/lint の該当コマンドを実行したか
+   - Web Components 変更では Network 件数または fetch 呼び出し数を確認したか
+   - rate limit 回避を実装した場合、単に制限値を上げただけで終わっていないか

--- a/docs/roadmap/dev-doctrine-roadmap.md
+++ b/docs/roadmap/dev-doctrine-roadmap.md
@@ -1,0 +1,76 @@
+# Dev Doctrine Roadmap
+
+最終更新: 2026-06-01
+
+進捗の正本は GitHub Issue と dev note に置く。この文書は、設計先行で進めるための
+phase 分割だけを持つ。
+
+## Phase 1: Read batching の設計確定
+
+対象 Issue: https://github.com/kako-jun/nostalgic/issues/4
+
+実装前に決めること:
+
+- `visit` / `like` の共通 batching client の置き場
+- Web Components から使う public API
+- Osaka Kenpo など外部 React app から使う形
+- `like.batchGet` は `id` / `total` / `liked` を返す
+- `visit.batchGet` は `id` / `total` / `today` / `yesterday` / `week` / `month` を返す
+
+完了条件:
+
+- `batchIncrement` を作らない方針が docs と Issue に明記されている
+- Counter の一覧表示と個別閲覧の責務が分かれている
+- 既存 `batchGet` の後方互換には縛られず、新しい正規レスポンスに寄せる
+
+## Phase 2: Counter / Like の自動 batch/dedupe
+
+対象:
+
+- `apps/web/public/components/visit.js`
+- `apps/web/public/components/like.js`
+- 必要に応じて `apps/api/src/routes/visit.ts`
+- 必要に応じて `apps/api/src/routes/like.ts`
+
+方針:
+
+- 同一ページ内の同じ service 種別をページ全体で queue する
+- 同一 ID を dedupe する
+- chunk 上限を明示する
+- 短い TTL cache を持つ
+- `increment` / `toggle` は集約しない
+
+## Phase 3: Osaka Kenpo の明示 batchGet 移行
+
+対象:
+
+- `/home/d131/repos/2025/osaka-kenpo/src/app/law/[law_category]/[law]/components/ArticleListWithEeyan.tsx`
+- `/home/d131/repos/2025/osaka-kenpo/src/lib/eeyan.ts`
+
+方針:
+
+- 条文一覧は read-only のまま
+- Like と Counter の表示取得だけ共通 batching client へ寄せる
+- 条文個別ページの `increment` は単発のまま
+
+## Phase 4: Ranking / BBS / Yokoso の重複通信点検
+
+対象:
+
+- `apps/web/public/components/ranking.js`
+- `apps/web/public/components/bbs.js`
+- `apps/web/public/components/yokoso.js`
+
+方針:
+
+- まず同一 ID の in-flight dedupe/cache を入れる
+- 複数 ID の batch API が必要かは、デモページの通信数と実利用から判断する
+- batch API が必要なら Counter / Like とは別 Issue にする
+
+## Phase 5: Rate limit の再評価
+
+方針:
+
+- batching/dedupe 後の通信数を測ってから `RATE_LIMIT_MAX` を判断する
+- 読み取りと mutation の rate limit を分けるか検討する
+- 429 を単に隠すのではなく、通信数が減ったことを Network で確認する

--- a/docs/self-review/2026-06-01-baseline.md
+++ b/docs/self-review/2026-06-01-baseline.md
@@ -1,0 +1,26 @@
+# Baseline Review
+
+実施日: 2026-06-01
+
+`/dev-doctrine nostalgic init` の初回診断。
+
+| 観点                    | 状態     | 根拠                                                                                                   |
+| ----------------------- | -------- | ------------------------------------------------------------------------------------------------------ |
+| docs 正本               | 一部あり | `docs/user-guide/` と `docs/development/` はあるが、実装規約と system architecture がなかった          |
+| 定義データと状態の分離  | 概ね良い | `apps/web/src/config/services/*Steps.tsx` が UI 手順定義、React pages が runtime state を持つ          |
+| API route の責務分離    | 概ね良い | `apps/api/src/routes/{visit,like,ranking,bbs,yokoso}.ts` で service 別に分かれている                   |
+| 共通 core               | 良い     | `apps/api/src/lib/core/{auth,crypto,db,id,webhook}.ts` に横断処理がある                                |
+| Web Components 防御方針 | 良い     | `docs/development/webcomponents-defensive-programming.md` が存在し、`safeGetAttribute` パターンがある  |
+| 読み取り通信の重複排除  | 要改善   | `visit.js` / `like.js` / `ranking.js` / `bbs.js` / `yokoso.js` が個別 fetch 中心。Issue #4 で対応予定  |
+| Counter のイベント境界  | 注意     | `visit.js` は同一 ID の increment を `counted` で抑制しているが、画像形式や read path の通信共有が弱い |
+| batch API               | 方針更新 | `visit` / `like` の `batchGet` は後方互換に縛られず、各 service の正規データを返す方向にする           |
+| 非ゲーム profile        | 適用外   | Nostalgic は Web/API platform であり GameState 規約は不要                                              |
+
+初回で追加した docs:
+
+- `docs/design/system-architecture.md`
+- `docs/guidelines/implementation.md`
+- `docs/guidelines/self-review-prompt.md`
+- `docs/roadmap/dev-doctrine-roadmap.md`
+- `docs/self-review/README.md`
+- `docs/self-review/2026-06-01-baseline.md`

--- a/docs/self-review/README.md
+++ b/docs/self-review/README.md
@@ -1,0 +1,12 @@
+# Self Review
+
+このディレクトリには、`docs/guidelines/` に照らしたセルフレビュー結果を置く。
+
+運用:
+
+- 大きな Issue の実装前後でレビューを残す
+- 指摘は should / nit も含めて記録する
+- その場で直さないものは GitHub Issue または roadmap に移す
+- guidelines を更新すべき学びがあれば `docs/guidelines/` に反映する
+
+レビュー時の観点は `docs/guidelines/self-review-prompt.md` を使う。

--- a/docs/user-guide/services/counter.md
+++ b/docs/user-guide/services/counter.md
@@ -257,16 +257,16 @@ Content-Type: application/json
 {
   "success": true,
   "data": {
-    "id1": { "total": 100 },
-    "id2": { "total": 42 },
-    "id3": { "total": 0 }
+    "id1": { "id": "id1", "total": 100, "today": 3, "yesterday": 2, "week": 18, "month": 42 },
+    "id2": { "id": "id2", "total": 42, "today": 0, "yesterday": 1, "week": 8, "month": 21 },
+    "id3": { "id": "id3", "total": 0, "today": 0, "yesterday": 0, "week": 0, "month": 0 }
   }
 }
 ```
 
 **Notes:**
 
-- IDs that don't exist return `{ "total": 0 }`
+- IDs that don't exist return all counter fields with `0`
 - Maximum 1000 IDs per request
 
 ### batchCreate

--- a/docs/user-guide/services/like.md
+++ b/docs/user-guide/services/like.md
@@ -199,18 +199,18 @@ Content-Type: application/json
 {
   "success": true,
   "data": {
-    "id1": { "total": 5 },
-    "id2": { "total": 12 },
-    "id3": { "total": 0 }
+    "id1": { "id": "id1", "total": 5, "liked": true },
+    "id2": { "id": "id2", "total": 12, "liked": false },
+    "id3": { "id": "id3", "total": 0, "liked": false }
   }
 }
 ```
 
 **Notes:**
 
-- IDs that don't exist return `{ "total": 0 }`
+- IDs that don't exist return `{ "id": "...", "total": 0, "liked": false }`
 - Maximum 1000 IDs per request
-- Does not return `liked` state (use individual `get` for that)
+- `liked` is calculated for the current requester, using the same user hash logic as individual `get`
 
 **Usage Example:**
 
@@ -228,7 +228,8 @@ const { data } = await response.json();
 // Display in list
 articles.forEach(article => {
   const likes = data[article.likeId]?.total || 0;
-  console.log(`${article.title}: ${likes} likes`);
+  const liked = data[article.likeId]?.liked || false;
+  console.log(`${article.title}: ${likes} likes, liked=${liked}`);
 });
 ```
 


### PR DESCRIPTION
## 関連 Issue
Refs #4

## 変更内容
- Counter / Like の batchGet を正規レスポンスへ更新
  - Like: id / total / liked
  - Counter: id / total / today / yesterday / week / month
- Web Components の Counter / Like 読み取りをページ全体で自動 batch/dedupe/cache
- batchGet を read-only POST として全 origin CORS 許可
- /dev-doctrine nostalgic init の docs/guidelines/roadmap/self-review を追加
- user-guide の batchGet 仕様を更新

## 方針
- batchIncrement は追加しない
- Counter increment は単発イベントのまま
- batchGet の後方互換性は不要として新仕様へ寄せる

## 検証
- env -u NODE_OPTIONS pnpm --filter @nostalgic/api exec tsc --noEmit
- env -u NODE_OPTIONS pnpm --filter @nostalgic/web build
- env -u NODE_OPTIONS pnpm lint
- node --check apps/web/public/components/like.js
- node --check apps/web/public/components/visit.js