### PR TITLE
feat: ranking/bbs/yokoso に読み取りの in-flight dedupe + 短期cache (#6)

### DIFF
--- a/apps/web/public/components/bbs.js
+++ b/apps/web/public/components/bbs.js
@@ -120,6 +120,50 @@ class NostalgicBBS extends HTMLElement {
   // APIのベースURL
   static apiBaseUrl = "https://api.nostalgic.llll-ll.com";
 
+  // --- 読み取りの in-flight dedupe（dev-doctrine Phase 4 / Issue #6）---
+  // bbs は1ページに通常1個（singleton）かつ内容が多人数の投稿で揮発的・ページング有り。
+  // そのため TTL キャッシュは入れず（他者の投稿直後の stale を避ける）、dedupe のみ（ttl=0）。
+  // 同時並行の同一 (id, page) GET を1本に畳む。投稿/削除など自分の mutation 後は invalidateId で
+  // その id の in-flight を破棄し、リロードが必ず最新を取りに行くようにする。
+  static _readCache = new Map(); // key -> { result, expiresAt }（ttl=0 のため実質未使用）
+  static _inflight = new Map(); // key -> Promise<{ ok, status, data }>
+  static _readCacheTtlMs = 0; // dedupe のみ（キャッシュしない）
+
+  // 同一 key への並行 GET を1本に畳んで返す（ttl>0 のときだけ成功応答を短期キャッシュ）。
+  // 戻り値 { ok, status, data } で従来の success 判定をそのまま使える。
+  static sharedRead(key, url) {
+    const ttl = this._readCacheTtlMs;
+    if (ttl > 0) {
+      const cached = this._readCache.get(key);
+      if (cached && cached.expiresAt > Date.now()) return Promise.resolve(cached.result);
+      if (cached) this._readCache.delete(key);
+    }
+    const inflight = this._inflight.get(key);
+    if (inflight) return inflight;
+    const promise = fetch(url)
+      .then(async (res) => ({ ok: res.ok, status: res.status, data: await res.json() }))
+      .then((result) => {
+        if (ttl > 0 && result.ok && result.data && result.data.success) {
+          this._readCache.set(key, { result, expiresAt: Date.now() + ttl });
+        }
+        return result;
+      })
+      .finally(() => {
+        this._inflight.delete(key);
+      });
+    this._inflight.set(key, promise);
+    return promise;
+  }
+
+  // mutation（投稿/編集/削除）後に、その id の全ページの dedupe/cache を破棄する。
+  // 投稿前から走っていた in-flight GET をリロードが再利用して stale を表示するのを防ぐ。
+  static invalidateId(idKeyPrefix) {
+    for (const k of [...this._readCache.keys()])
+      if (k.startsWith(idKeyPrefix)) this._readCache.delete(k);
+    for (const k of [...this._inflight.keys()])
+      if (k.startsWith(idKeyPrefix)) this._inflight.delete(k);
+  }
+
   constructor() {
     super();
     this.attachShadow({ mode: "open" });
@@ -216,13 +260,15 @@ class NostalgicBBS extends HTMLElement {
       this.loading = true;
       this.render();
 
-      const response = await fetch(
-        `${NostalgicBBS.apiBaseUrl}/bbs?action=get&id=${encodeURIComponent(id)}&page=${this.currentPage}`
-      );
-      const data = await response.json();
+      // 並行する同一 (id, page) GET は1本に畳まれる（ttl=0 のため再取得キャッシュはしない）。
+      const url = `${NostalgicBBS.apiBaseUrl}/bbs?action=get&id=${encodeURIComponent(id)}&page=${this.currentPage}`;
+      const key = `${NostalgicBBS.apiBaseUrl}|${id}|${this.currentPage}`;
+      const { data } = await NostalgicBBS.sharedRead(key, url);
 
       if (data.success) {
-        this.bbsData = data.data;
+        // dedupe で同一 (id, page) の複数ウィジェットが同じ parsed オブジェクトを共有しうるため、
+        // totalPages/pagination を書き込む前に浅くコピーして共有オブジェクトを汚さない（messages は読み取りのみ）。
+        this.bbsData = { ...data.data };
         // Calculate pagination from API response
         const messagesPerPage = this.bbsData.messagesPerPage || 20;
         const totalMessages = this.bbsData.totalMessages || this.bbsData.messages.length;
@@ -1274,6 +1320,8 @@ class NostalgicBBS extends HTMLElement {
         // 編集モードをクリア
         this.clearEditMode();
 
+        // 自分の投稿/編集が反映されるよう、この id の dedupe/in-flight を破棄してから再読み込み
+        NostalgicBBS.invalidateId(`${NostalgicBBS.apiBaseUrl}|${this.safeGetAttribute("id")}|`);
         // 新しい投稿が表示される最後のページに移動して再読み込み
         await this.loadBBSData();
         const lastPage = this.bbsData.totalPages || 1;
@@ -1450,6 +1498,8 @@ class NostalgicBBS extends HTMLElement {
       const data = await response.json();
 
       if (data.success) {
+        // 削除を反映させるため、この id の dedupe/in-flight を破棄してから再読み込み
+        NostalgicBBS.invalidateId(`${NostalgicBBS.apiBaseUrl}|${this.safeGetAttribute("id")}|`);
         // BBSデータを再読み込み
         await this.loadBBSData();
         this.showMessage(this.t.messageDeleted, "success");

--- a/apps/web/public/components/ranking.js
+++ b/apps/web/public/components/ranking.js
@@ -35,6 +35,42 @@ class NostalgicRanking extends HTMLElement {
   // APIのベースURL
   static apiBaseUrl = "https://api.nostalgic.llll-ll.com";
 
+  // --- 読み取りの in-flight dedupe + 短期 TTL キャッシュ（dev-doctrine Phase 4 / Issue #6）---
+  // ranking は1ページに通常1個（singleton）運用。visit/like の batchGet と違い複数 ID batch の
+  // 価値は薄いので、サーバ API は増やさず、クライアントで「同時並行の同一 GET 畳み込み + 短時間の
+  // 再取得キャッシュ」だけ入れて実在の冗長通信を消す。ranking ウィジェットは読み取り専用
+  // （mutation なし）なので 5s TTL キャッシュも安全。
+  static _readCache = new Map(); // key -> { result, expiresAt }
+  static _inflight = new Map(); // key -> Promise<{ ok, status, data }>
+  static _readCacheTtlMs = 5000; // 0 なら dedupe のみ（キャッシュしない）
+
+  // 同一 key への並行 GET を1本に畳み、成功応答だけ短時間キャッシュして返す。
+  // 戻り値 { ok, status, data } で各コンポーネントの従来の ok/success 判定をそのまま使える。
+  static sharedRead(key, url) {
+    const ttl = this._readCacheTtlMs;
+    if (ttl > 0) {
+      const cached = this._readCache.get(key);
+      if (cached && cached.expiresAt > Date.now()) return Promise.resolve(cached.result);
+      if (cached) this._readCache.delete(key);
+    }
+    const inflight = this._inflight.get(key);
+    if (inflight) return inflight;
+    const promise = fetch(url)
+      .then(async (res) => ({ ok: res.ok, status: res.status, data: await res.json() }))
+      .then((result) => {
+        // 成功応答のみ短期キャッシュ（エラーは即時再試行できるようキャッシュしない）
+        if (ttl > 0 && result.ok && result.data && result.data.success) {
+          this._readCache.set(key, { result, expiresAt: Date.now() + ttl });
+        }
+        return result;
+      })
+      .finally(() => {
+        this._inflight.delete(key);
+      });
+    this._inflight.set(key, promise);
+    return promise;
+  }
+
   constructor() {
     super();
     this.attachShadow({ mode: "open" });
@@ -113,8 +149,9 @@ class NostalgicRanking extends HTMLElement {
         url += `&limit=${encodeURIComponent(limit)}`;
       }
 
-      const response = await fetch(url);
-      const data = await response.json();
+      // limit でデータが変わるので key に含める。並行する同一 GET は1本に畳まれる。
+      const key = `${NostalgicRanking.apiBaseUrl}|${id}|${limit || ""}`;
+      const { data } = await NostalgicRanking.sharedRead(key, url);
 
       if (data.success) {
         this.rankingData = data.data;

--- a/apps/web/public/components/yokoso.js
+++ b/apps/web/public/components/yokoso.js
@@ -32,6 +32,42 @@ class NostalgicYokoso extends HTMLElement {
   // APIのベースURL
   static apiBaseUrl = "https://api.nostalgic.llll-ll.com";
 
+  // --- 読み取りの in-flight dedupe + 短期 TTL キャッシュ（dev-doctrine Phase 4 / Issue #6）---
+  // yokoso は1ページに通常1個（singleton）。visit/like の batchGet と違い複数 ID batch の価値は
+  // 薄いので、サーバ API は増やさず、クライアントで「同時並行の同一 GET 畳み込み + 短時間の再取得
+  // キャッシュ」だけ入れる。yokoso は読み取り専用（ウィジェットからの mutation なし）の
+  // ほぼ静的な歓迎バナーなので 5s TTL キャッシュも安全。`format=image` は <img src> なので対象外。
+  static _readCache = new Map(); // key -> { result, expiresAt }
+  static _inflight = new Map(); // key -> Promise<{ ok, status, data }>
+  static _readCacheTtlMs = 5000; // 0 なら dedupe のみ（キャッシュしない）
+
+  // 同一 key への並行 GET を1本に畳み、成功応答だけ短時間キャッシュして返す。
+  // 戻り値 { ok, status, data } で各コンポーネントの従来の ok/success 判定をそのまま使える。
+  static sharedRead(key, url) {
+    const ttl = this._readCacheTtlMs;
+    if (ttl > 0) {
+      const cached = this._readCache.get(key);
+      if (cached && cached.expiresAt > Date.now()) return Promise.resolve(cached.result);
+      if (cached) this._readCache.delete(key);
+    }
+    const inflight = this._inflight.get(key);
+    if (inflight) return inflight;
+    const promise = fetch(url)
+      .then(async (res) => ({ ok: res.ok, status: res.status, data: await res.json() }))
+      .then((result) => {
+        // 成功応答のみ短期キャッシュ（エラーは即時再試行できるようキャッシュしない）
+        if (ttl > 0 && result.ok && result.data && result.data.success) {
+          this._readCache.set(key, { result, expiresAt: Date.now() + ttl });
+        }
+        return result;
+      })
+      .finally(() => {
+        this._inflight.delete(key);
+      });
+    this._inflight.set(key, promise);
+    return promise;
+  }
+
   constructor() {
     super();
     this.attachShadow({ mode: "open" });
@@ -105,12 +141,13 @@ class NostalgicYokoso extends HTMLElement {
       const baseUrl = this.safeGetAttribute("api-base") || NostalgicYokoso.apiBaseUrl;
       const apiUrl = `${baseUrl}/yokoso?action=get&id=${encodeURIComponent(id)}`;
 
-      const response = await fetch(apiUrl);
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}`);
+      // 並行する同一 GET は1本に畳まれる。ok/success 判定は従来どおり呼び出し側で行う。
+      const key = `${baseUrl}|${id}`;
+      const { ok, status, data: responseData } = await NostalgicYokoso.sharedRead(key, apiUrl);
+      if (!ok) {
+        throw new Error(`HTTP ${status}`);
       }
 
-      const responseData = await response.json();
       if (responseData.success) {
         this.yokosoData = responseData.data;
       } else {

--- a/docs/design/system-architecture.md
+++ b/docs/design/system-architecture.md
@@ -81,4 +81,10 @@ React 側の `apps/web/src/utils/apiHelpers.ts` と `apps/web/src/hooks/useFetch
 - `visit.ts` / `like.ts` には `batchGet` がある。Web Components はこれを内部利用して読み取りを集約する
 - `like` の `batchGet` は `id` / `total` / 現在ユーザーの `liked` を返す正規の一覧取得 API とする
 - `visit` の `batchGet` は `id` / `total` / `today` / `yesterday` / `week` / `month` を返す正規の一覧取得 API とする
-- `ranking` / `bbs` / `yokoso` には batch API がない。まず同一 ID の in-flight dedupe/cache で足りるか判断する
+- `ranking` / `bbs` / `yokoso` には batch API を設けない。これらは1ページに通常1個（singleton）運用で、
+  複数 ID batch の価値が薄いため。代わりに各 Web Component にクライアント側の
+  **in-flight dedupe + 短期 TTL 読み取りキャッシュ**（静的 `sharedRead(key, url)`）を入れ、同時並行の
+  同一 ID GET を1本に畳む。`ranking` / `yokoso` は読み取り専用なので 5s TTL キャッシュ込み、
+  `bbs` は内容が揮発的（多人数投稿）かつページング有りのため **dedupe のみ（TTL=0）** とし、
+  自分の投稿/削除後は `invalidateId` で in-flight を破棄してリロードを最新化する。
+  将来、同一ページに同種ウィジェットを多数並べる実利用が出たら、そのとき複数 ID batch API を別途検討する


### PR DESCRIPTION
## 概要

dev-doctrine Phase 4。visit/like（#5 で batchGet 化済み）に続き、残る3つの Web Component の読み取り通信の重複を排除する。

これら3つは**1ページに通常1個（singleton）運用**で複数 ID batchGet の価値が薄いため、サーバ API は増やさず、各コンポーネントにクライアント側の静的 `sharedRead(key, url)` を入れて**同時並行の同一 ID GET を1本に畳む**。

## 変更

- **ranking / yokoso**: in-flight dedupe + 5s TTL read cache（読み取り専用なので安全）
- **bbs**: dedupe のみ（TTL=0、多人数投稿で揮発的・ページング有り）。投稿/削除後は `invalidateId` で in-flight を破棄しリロードを最新化
- 成功応答のみキャッシュ（エラーは即時再試行）。reject は in-flight を残さず伝播（poison しない）
- bbs は dedupe で共有しうる parsed オブジェクトを汚さないよう浅くコピーしてから `totalPages`/`pagination` を書く。invalidate prefix は load key と同じ `safeGetAttribute("id")` に統一
- `docs/design/system-architecture.md` を実装に合わせて更新（batch API を設けない理由を明記）

## 挙動の不変性

各コンポーネントの `ok`/`success` 判定はそのまま使用。yokoso の `!response.ok → throw` も `{ok,status}` で維持。独立レビューで visit/like パターンとの整合・3つの yokoso ケース（!ok+JSON / !ok+非JSON / ok+success:false）・bbs 共有オブジェクト mutation・invalidation を検証、blocker なし。

## 検証

このリポは vanilla Web Components で JS テスト基盤・CI が無いため:
- 3ファイル `node --check` 構文OK
- `sharedRead`/`invalidateId` ロジックを忠実再現した Node スクリプトで dedupe / TTL命中 / ttl=0 / エラー非キャッシュ / reject非poison / invalidateId を**13アサーション緑**で実証
- 独立レビュー（サブエージェント）で挙動等価を確認

**残る手動確認（推奨）**: 本番 API に対し実ウィジェットを2個並べて Network で GET が1本に畳まれることを目視（read-only で安全）。

Closes #6