### PR TITLE
fix(bbs): dedupe-only を 3s TTL キャッシュに変更（実機検証の反映）

### DIFF
--- a/apps/web/public/components/bbs.js
+++ b/apps/web/public/components/bbs.js
@@ -120,14 +120,15 @@ class NostalgicBBS extends HTMLElement {
   // APIのベースURL
   static apiBaseUrl = "https://api.nostalgic.llll-ll.com";
 
-  // --- 読み取りの in-flight dedupe（dev-doctrine Phase 4 / Issue #6）---
-  // bbs は1ページに通常1個（singleton）かつ内容が多人数の投稿で揮発的・ページング有り。
-  // そのため TTL キャッシュは入れず（他者の投稿直後の stale を避ける）、dedupe のみ（ttl=0）。
-  // 同時並行の同一 (id, page) GET を1本に畳む。投稿/削除など自分の mutation 後は invalidateId で
-  // その id の in-flight を破棄し、リロードが必ず最新を取りに行くようにする。
-  static _readCache = new Map(); // key -> { result, expiresAt }（ttl=0 のため実質未使用）
+  // --- 読み取りの in-flight dedupe + 短期 TTL キャッシュ（dev-doctrine Phase 4 / Issue #6）---
+  // bbs は内容が多人数の投稿で揮発的・ページング有り。実機検証で「複数ウィジェットは逐次ロード
+  // され同時並行ではない」と判明したため、inflight dedupe だけでは重複が畳まれない。実トラフィック
+  // 削減の本体は TTL キャッシュなので bbs にも入れるが、揮発性に配慮して ranking/yokoso(5s)より短い
+  // 3s に抑える。投稿/編集/削除など自分の mutation 後は invalidateId で (id,*) の cache/in-flight を
+  // 破棄し、リロードが必ず最新を取りに行くようにする（他者投稿の stale は最長 3s で解消）。
+  static _readCache = new Map(); // key -> { result, expiresAt }
   static _inflight = new Map(); // key -> Promise<{ ok, status, data }>
-  static _readCacheTtlMs = 0; // dedupe のみ（キャッシュしない）
+  static _readCacheTtlMs = 3000; // 揮発的なので短め（ranking/yokoso は 5000）
 
   // 同一 key への並行 GET を1本に畳んで返す（ttl>0 のときだけ成功応答を短期キャッシュ）。
   // 戻り値 { ok, status, data } で従来の success 判定をそのまま使える。

--- a/docs/design/system-architecture.md
+++ b/docs/design/system-architecture.md
@@ -83,8 +83,13 @@ React 側の `apps/web/src/utils/apiHelpers.ts` と `apps/web/src/hooks/useFetch
 - `visit` の `batchGet` は `id` / `total` / `today` / `yesterday` / `week` / `month` を返す正規の一覧取得 API とする
 - `ranking` / `bbs` / `yokoso` には batch API を設けない。これらは1ページに通常1個（singleton）運用で、
   複数 ID batch の価値が薄いため。代わりに各 Web Component にクライアント側の
-  **in-flight dedupe + 短期 TTL 読み取りキャッシュ**（静的 `sharedRead(key, url)`）を入れ、同時並行の
-  同一 ID GET を1本に畳む。`ranking` / `yokoso` は読み取り専用なので 5s TTL キャッシュ込み、
-  `bbs` は内容が揮発的（多人数投稿）かつページング有りのため **dedupe のみ（TTL=0）** とし、
-  自分の投稿/削除後は `invalidateId` で in-flight を破棄してリロードを最新化する。
-  将来、同一ページに同種ウィジェットを多数並べる実利用が出たら、そのとき複数 ID batch API を別途検討する
+  **in-flight dedupe + 短期 TTL 読み取りキャッシュ**（静的 `sharedRead(key, url)`）を入れ、
+  同一 ID の読み取りを1リクエストに畳む。
+- **実トラフィック削減の本体は TTL キャッシュ**。実機検証（Playwright）で、複数ウィジェットは
+  同時並行ではなく**逐次ロード**されると判明したため、in-flight dedupe（同時並行のみ畳む）だけでは
+  別ウィジェットの重複が消えない。逐次の2個目を畳むのは TTL キャッシュ側。よって全 service に
+  TTL を入れる: `ranking` / `yokoso` は読み取り専用で 5s、`bbs` は揮発的（多人数投稿）なので短め 3s。
+- `bbs` は自分の投稿/編集/削除後に `invalidateId` で `(id, *)` の cache/in-flight を破棄してリロードを
+  最新化する（他者投稿による stale は最長 TTL=3s で解消）。
+- 検証: 6ウィジェット（各 service 2個）→ 実 GET 3本（各 service 1本）に畳まれることを実機で確認済み。
+- 将来、同一ページに同種ウィジェットを多数並べる実利用が出たら、そのとき複数 ID batch API を別途検討する


### PR DESCRIPTION
## 概要

Phase 4（#6/PR #7）の **実機検証（Playwright）** で見つかった改善。bbs を dedupe-only（TTL=0）から **3s TTL キャッシュ**に変える。

## 実機検証で分かったこと

編集済みコンポーネントをローカル配信し、各 service のウィジェットを2個ずつ並べたページを Playwright（実 Chromium）で開いて本番 API への GET を数えた:

| service | 変更前 | 原因 |
|---|---|---|
| ranking | 2個→**1 GET** ✅ | 5s TTL キャッシュが2個目を畳む |
| yokoso | 2個→**1 GET** ✅ | 同上（404 の `!ok→空データ` 経路も正常踏破） |
| bbs | 2個→**2 GET** ❌ | TTL=0 で2個目が畳まれない |

→ **複数ウィジェットは同時並行ではなく逐次ロードされる**ため、in-flight dedupe（同時並行のみ畳む）だけでは別ウィジェットの重複が消えない。実トラフィック削減の本体は **TTL キャッシュ**だった。

## 変更

- bbs `_readCacheTtlMs` を `0` → `3000`（揮発的なので ranking/yokoso の 5s より短く）。mutation 後の `invalidateId` は cache にも効くので他者投稿の stale は最長 3s で解消
- `docs/design/system-architecture.md` を実測知見に更新

## 再検証

修正後に同じ実機テストを再実行 → **6ウィジェット（各 service 2個）→ 実 GET 3本（各 service 1本）** に畳まれることを確認。全ウィジェット描画成功・未捕捉エラーゼロ。

これで dev-doctrine の「完了判定は実機での仕様達成」を満たす。