### PR TITLE
fix(api): batchGet が ~98 ids 以上で 500 になるのを内部サブチャンクで解消

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -2,9 +2,12 @@
   "name": "@nostalgic/api",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
+    "test": "node --experimental-strip-types --test 'src/**/*.test.ts'",
+    "typecheck": "tsc --noEmit",
     "db:init": "wrangler d1 execute nostalgic-db --local --file=schema.sql",
     "db:local": "wrangler d1 execute nostalgic-db --local",
     "db:remote": "wrangler d1 execute nostalgic-db --remote"

--- a/apps/api/src/lib/core/batch.test.ts
+++ b/apps/api/src/lib/core/batch.test.ts
@@ -1,0 +1,90 @@
+/**
+ * batch.ts のユニットテスト
+ *
+ * テスト基盤（vitest 等）は未導入のため、Node 標準の `node:test` ランナーと
+ * `node:assert` を使い、Node v24 の TypeScript type-stripping で直接実行する
+ * ゼロ依存テストにしてある。
+ *   実行: pnpm --filter @nostalgic/api test
+ *   （= node --experimental-strip-types --test 'src/**​/*.test.ts'）
+ *
+ * 観点:
+ *  - chunkArray が全件を「重複なく・順序を保ったまま」被覆する（batchGet で欠落しない証明）
+ *  - 閾値超（98 / 100 / 200 / 1000 件）でも各チャンクが D1 の 100 バインド上限を超えない
+ *    （like の likedQuery は chunkSize+3 バインドになるため、その値が 100 未満であること）
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { chunkArray, BATCH_GET_CHUNK_SIZE } from "./batch.ts";
+
+// 連結すると元配列に完全一致する（順序保持 + 全件被覆 + 重複なし）
+function assertCovers<T>(original: readonly T[], chunks: T[][], size: number): void {
+  const flat = chunks.flat();
+  assert.deepEqual(flat, [...original], "chunks concatenated must equal the original array");
+  for (const chunk of chunks) {
+    assert.ok(chunk.length >= 1, "no empty chunk");
+    assert.ok(chunk.length <= size, `chunk size <= ${size}`);
+  }
+  // 端数を除く全チャンクはちょうど size であること
+  for (let i = 0; i < chunks.length - 1; i++) {
+    assert.equal(chunks[i].length, size, "non-last chunks are exactly size");
+  }
+}
+
+test("chunkArray: empty array -> no chunks", () => {
+  assert.deepEqual(chunkArray([], 50), []);
+});
+
+test("chunkArray: fewer than size -> single chunk", () => {
+  const ids = Array.from({ length: 10 }, (_, i) => `id-${i}`);
+  const chunks = chunkArray(ids, 50);
+  assert.equal(chunks.length, 1);
+  assertCovers(ids, chunks, 50);
+});
+
+test("chunkArray: exactly size -> single full chunk", () => {
+  const ids = Array.from({ length: 50 }, (_, i) => `id-${i}`);
+  const chunks = chunkArray(ids, 50);
+  assert.equal(chunks.length, 1);
+  assertCovers(ids, chunks, 50);
+});
+
+test("chunkArray: size+1 -> two chunks (50 + 1)", () => {
+  const ids = Array.from({ length: 51 }, (_, i) => `id-${i}`);
+  const chunks = chunkArray(ids, 50);
+  assert.equal(chunks.length, 2);
+  assert.equal(chunks[0].length, 50);
+  assert.equal(chunks[1].length, 1);
+  assertCovers(ids, chunks, 50);
+});
+
+// 実機で 500 になっていた閾値超のケースを網羅
+for (const total of [98, 100, 200, 1000]) {
+  test(`chunkArray: ${total} ids -> 全件を欠落なく被覆する`, () => {
+    const ids = Array.from({ length: total }, (_, i) => `like-${i}`);
+    const chunks = chunkArray(ids, BATCH_GET_CHUNK_SIZE);
+    assertCovers(ids, chunks, BATCH_GET_CHUNK_SIZE);
+    // 全 ID が重複なく現れる
+    const seen = new Set(chunks.flat());
+    assert.equal(seen.size, total, "no id is dropped or duplicated");
+  });
+}
+
+test("BATCH_GET_CHUNK_SIZE: 各チャンクは D1 の 100 バインド上限を超えない", () => {
+  // like batchGet の likedQuery が最もバインドが多い:
+  // IN(...N...) + user_hash + date + action_type = N+3
+  const likeWorstCaseBinds = BATCH_GET_CHUNK_SIZE + 3;
+  assert.ok(
+    likeWorstCaseBinds < 100,
+    `like worst-case binds (${likeWorstCaseBinds}) must stay under SQLite limit 100`
+  );
+  // visit batchGet の dailyQuery: IN(...N...) + monthStart = N+1
+  const visitBinds = BATCH_GET_CHUNK_SIZE + 1;
+  assert.ok(visitBinds < 100, `visit dailyQuery binds (${visitBinds}) must stay under 100`);
+});
+
+test("chunkArray: size が不正なら例外", () => {
+  assert.throws(() => chunkArray([1, 2, 3], 0));
+  assert.throws(() => chunkArray([1, 2, 3], -1));
+  assert.throws(() => chunkArray([1, 2, 3], 1.5));
+});

--- a/apps/api/src/lib/core/batch.ts
+++ b/apps/api/src/lib/core/batch.ts
@@ -1,0 +1,45 @@
+/**
+ * Batch utilities
+ *
+ * D1 (SQLite) は 1 ステートメントあたりのバインド変数を 100 個までしか許可しない
+ * (SQLITE_MAX_VARIABLE_NUMBER = 100)。batchGet は `WHERE service_id IN (?,?,...)`
+ * を組み立てるため、ids が ~98 件を超えると bind 変数が 100 を超えて D1 が 500 を返す。
+ *
+ * 実測閾値:
+ *  - like batchGet: likedQuery が `IN (...N...) AND user_hash=? AND date=? AND action_type=?`
+ *    で N+3 バインド。N=97 で 100、N=98 で 101 → 500（実機で 97/98 が境界と一致）。
+ *  - visit batchGet: dailyQuery が `IN (...N...) AND date>=?` で N+1 バインド。N=99 で境界。
+ *
+ * MAX_BATCH_SIZE(=1000) まで広告どおり受け付けるため、ハンドラ側で ids を
+ * D1 が安全に処理できるサイズに内部サブチャンクし、各チャンクの結果をマージして返す。
+ */
+
+/**
+ * batchGet の内部 D1 サブチャンクサイズ。
+ *
+ * 最もバインドの多いクエリ（like の likedQuery: N+3 バインド）でも
+ * 50+3=53 と 100 の半分以下に収め、固定列が増えても安全マージンを残す。
+ */
+export const BATCH_GET_CHUNK_SIZE = 50;
+
+/**
+ * 配列を指定サイズのチャンクに分割する純粋関数。
+ *
+ * - 元の順序を保持する
+ * - 全要素を重複なく被覆する（連結すると元配列に等しい）
+ * - 端数は最後のチャンクに残る
+ * - 空配列は空配列を返す
+ *
+ * @param items 分割対象
+ * @param size  1 チャンクの最大要素数（1 以上）
+ */
+export function chunkArray<T>(items: readonly T[], size: number): T[][] {
+  if (size < 1 || !Number.isInteger(size)) {
+    throw new Error(`chunkArray: size must be a positive integer, got ${size}`);
+  }
+  const chunks: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size));
+  }
+  return chunks;
+}

--- a/apps/api/src/lib/core/index.ts
+++ b/apps/api/src/lib/core/index.ts
@@ -5,3 +5,4 @@ export { hashToken, verifyToken, validateOwnerToken } from "./auth";
 export * from "./id";
 export * from "./db";
 export * from "./constants";
+export * from "./batch";

--- a/apps/api/src/routes/like.ts
+++ b/apps/api/src/routes/like.ts
@@ -18,6 +18,7 @@ import { generatePublicId } from "../lib/core/id";
 import { generateUserHash } from "../lib/core/crypto";
 import { getTodayDateString } from "../lib/core/db";
 import { URL_CONST } from "../lib/core/constants";
+import { chunkArray, BATCH_GET_CHUNK_SIZE } from "../lib/core/batch";
 import { sendWebHook, WebHookMessages } from "../lib/core/webhook";
 
 type Bindings = { DB: D1Database };
@@ -560,44 +561,50 @@ app.post("/", async (c) => {
     const userHash = await generateUserHash(ip, userAgent);
     const today = getTodayDateString();
 
-    // service_idのリストを構築
-    const serviceIds = uniqueIds.map((id) => `like:${id}:total`);
-    const actionServiceIds = uniqueIds.map((id) => `like:${id}`);
-
-    // D1はIN句のプレースホルダを動的に構築する必要がある
-    const placeholders = serviceIds.map(() => "?").join(",");
-    const actionPlaceholders = actionServiceIds.map(() => "?").join(",");
-    const totalsQuery = `SELECT service_id, total FROM likes WHERE service_id IN (${placeholders})`;
-    const likedQuery = `SELECT service_id, value FROM daily_actions WHERE service_id IN (${actionPlaceholders}) AND user_hash = ? AND date = ? AND action_type = ?`;
-
-    const [totalsResult, likedResult] = await Promise.all([
-      db
-        .prepare(totalsQuery)
-        .bind(...serviceIds)
-        .all<{ service_id: string; total: number }>(),
-      db
-        .prepare(likedQuery)
-        .bind(...actionServiceIds, userHash, today, "like")
-        .all<{ service_id: string; value: string }>(),
-    ]);
-
-    // 結果をIDでマップ
     const data: Record<string, { id: string; total: number; liked: boolean }> = {};
-    for (const row of totalsResult.results || []) {
-      // "like:xxx:total" から "xxx" を抽出
-      const id = stripLikeTotalServiceId(row.service_id);
-      data[id] = { id, total: row.total, liked: false };
-    }
 
-    for (const row of likedResult.results || []) {
-      const id = stripLikeServiceId(row.service_id);
-      data[id] = { id, total: data[id]?.total ?? 0, liked: row.value === "liked" };
-    }
-
-    // リクエストされたが存在しないIDは0として含める
+    // 先に全 ID を 0 で初期化（存在しない ID も結果に含める）
     for (const id of uniqueIds) {
-      if (!data[id]) {
-        data[id] = { id, total: 0, liked: false };
+      data[id] = { id, total: 0, liked: false };
+    }
+
+    // D1 (SQLite) は 1 ステートメントあたり 100 バインド変数までしか許可しない。
+    // likedQuery は IN(...N...) + 3 固定列で N+3 バインドになるため、ids を内部で
+    // サブチャンクして各チャンクごとにクエリし、結果をマージする（直列実行で
+    // Workers の subrequest 上限と D1 同時接続に対して安全側に倒す）。
+    const idChunks = chunkArray(uniqueIds, BATCH_GET_CHUNK_SIZE);
+    for (const chunk of idChunks) {
+      // service_idのリストを構築
+      const serviceIds = chunk.map((id) => `like:${id}:total`);
+      const actionServiceIds = chunk.map((id) => `like:${id}`);
+
+      // D1はIN句のプレースホルダを動的に構築する必要がある
+      const placeholders = serviceIds.map(() => "?").join(",");
+      const actionPlaceholders = actionServiceIds.map(() => "?").join(",");
+      const totalsQuery = `SELECT service_id, total FROM likes WHERE service_id IN (${placeholders})`;
+      const likedQuery = `SELECT service_id, value FROM daily_actions WHERE service_id IN (${actionPlaceholders}) AND user_hash = ? AND date = ? AND action_type = ?`;
+
+      const [totalsResult, likedResult] = await Promise.all([
+        db
+          .prepare(totalsQuery)
+          .bind(...serviceIds)
+          .all<{ service_id: string; total: number }>(),
+        db
+          .prepare(likedQuery)
+          .bind(...actionServiceIds, userHash, today, "like")
+          .all<{ service_id: string; value: string }>(),
+      ]);
+
+      // 結果をIDでマップ
+      for (const row of totalsResult.results || []) {
+        // "like:xxx:total" から "xxx" を抽出
+        const id = stripLikeTotalServiceId(row.service_id);
+        data[id] = { id, total: row.total, liked: data[id]?.liked ?? false };
+      }
+
+      for (const row of likedResult.results || []) {
+        const id = stripLikeServiceId(row.service_id);
+        data[id] = { id, total: data[id]?.total ?? 0, liked: row.value === "liked" };
       }
     }
 

--- a/apps/api/src/routes/visit.ts
+++ b/apps/api/src/routes/visit.ts
@@ -20,6 +20,7 @@ import { generatePublicId } from "../lib/core/id";
 import { generateUserHash } from "../lib/core/crypto";
 import { getTodayDateString, getYesterdayDateString, getDateRange } from "../lib/core/db";
 import { DEFAULT_THEME, URL_CONST } from "../lib/core/constants";
+import { chunkArray, BATCH_GET_CHUNK_SIZE } from "../lib/core/batch";
 import { sendWebHook, WebHookMessages } from "../lib/core/webhook";
 
 type Bindings = {
@@ -641,61 +642,67 @@ app.post("/", async (c) => {
 
     const uniqueIds = [...new Set(ids)];
 
-    // service_idのリストを構築
-    const totalServiceIds = uniqueIds.map((id) => `counter:${id}:total`);
-    const dailyServiceIds = uniqueIds.map((id) => `counter:${id}`);
-
-    // D1はIN句のプレースホルダを動的に構築する必要がある
-    const totalPlaceholders = totalServiceIds.map(() => "?").join(",");
-    const dailyPlaceholders = dailyServiceIds.map(() => "?").join(",");
-    const totalsQuery = `SELECT service_id, total FROM counters WHERE service_id IN (${totalPlaceholders})`;
-    const dailyQuery = `SELECT service_id, date, count FROM counter_daily WHERE service_id IN (${dailyPlaceholders}) AND date >= ?`;
-
     const today = getTodayDateString();
     const yesterday = getYesterdayDateString();
     const weekStart = getDateRange(7).at(-1) || today;
     const monthStart = getDateRange(30).at(-1) || today;
 
-    const [totalsResult, dailyResult] = await Promise.all([
-      db
-        .prepare(totalsQuery)
-        .bind(...totalServiceIds)
-        .all<{ service_id: string; total: number }>(),
-      db
-        .prepare(dailyQuery)
-        .bind(...dailyServiceIds, monthStart)
-        .all<{ service_id: string; date: string; count: number }>(),
-    ]);
-
-    // 結果をIDでマップ
+    // 結果をIDでマップ（存在しない ID も 0 で含める）
     const data: Record<string, CounterData> = {};
     for (const id of uniqueIds) {
       data[id] = { id, total: 0, today: 0, yesterday: 0, week: 0, month: 0 };
     }
 
-    for (const row of totalsResult.results || []) {
-      // "counter:xxx:total" から "xxx" を抽出
-      const id = stripCounterTotalServiceId(row.service_id);
-      data[id] = {
-        ...(data[id] || { id, today: 0, yesterday: 0, week: 0, month: 0 }),
-        total: row.total,
-      };
-    }
+    // D1 (SQLite) は 1 ステートメントあたり 100 バインド変数までしか許可しない。
+    // dailyQuery は IN(...N...) + 1 固定列で N+1 バインドになるため、ids を内部で
+    // サブチャンクして各チャンクごとにクエリし、結果をマージする（直列実行）。
+    const idChunks = chunkArray(uniqueIds, BATCH_GET_CHUNK_SIZE);
+    for (const chunk of idChunks) {
+      // service_idのリストを構築
+      const totalServiceIds = chunk.map((id) => `counter:${id}:total`);
+      const dailyServiceIds = chunk.map((id) => `counter:${id}`);
 
-    for (const row of dailyResult.results || []) {
-      const id = stripCounterServiceId(row.service_id);
-      const item = data[id] || { id, total: 0, today: 0, yesterday: 0, week: 0, month: 0 };
-      if (row.date === today) {
-        item.today += row.count;
+      // D1はIN句のプレースホルダを動的に構築する必要がある
+      const totalPlaceholders = totalServiceIds.map(() => "?").join(",");
+      const dailyPlaceholders = dailyServiceIds.map(() => "?").join(",");
+      const totalsQuery = `SELECT service_id, total FROM counters WHERE service_id IN (${totalPlaceholders})`;
+      const dailyQuery = `SELECT service_id, date, count FROM counter_daily WHERE service_id IN (${dailyPlaceholders}) AND date >= ?`;
+
+      const [totalsResult, dailyResult] = await Promise.all([
+        db
+          .prepare(totalsQuery)
+          .bind(...totalServiceIds)
+          .all<{ service_id: string; total: number }>(),
+        db
+          .prepare(dailyQuery)
+          .bind(...dailyServiceIds, monthStart)
+          .all<{ service_id: string; date: string; count: number }>(),
+      ]);
+
+      for (const row of totalsResult.results || []) {
+        // "counter:xxx:total" から "xxx" を抽出
+        const id = stripCounterTotalServiceId(row.service_id);
+        data[id] = {
+          ...(data[id] || { id, today: 0, yesterday: 0, week: 0, month: 0 }),
+          total: row.total,
+        };
       }
-      if (row.date === yesterday) {
-        item.yesterday += row.count;
+
+      for (const row of dailyResult.results || []) {
+        const id = stripCounterServiceId(row.service_id);
+        const item = data[id] || { id, total: 0, today: 0, yesterday: 0, week: 0, month: 0 };
+        if (row.date === today) {
+          item.today += row.count;
+        }
+        if (row.date === yesterday) {
+          item.yesterday += row.count;
+        }
+        if (row.date >= weekStart) {
+          item.week += row.count;
+        }
+        item.month += row.count;
+        data[id] = item;
       }
-      if (row.date >= weekStart) {
-        item.week += row.count;
-      }
-      item.month += row.count;
-      data[id] = item;
     }
 
     return c.json({ success: true, data });

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -15,5 +15,5 @@
     "noEmit": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
 }


### PR DESCRIPTION
Closes #9

## 実機検証で確定した事実
本番 API を直接 curl して特定:
- `POST https://api.nostalgic.llll-ll.com/like?action=batchGet`（body `{"ids":[...]}`）が **ids 98 件以上で HTTP 500**、**97 件以下なら 200**。`visit` の batchGet も同様。
- 影響: osaka-kenpo の条文一覧（例: 刑法 = 100 条文超）が client 側で 100 件チャンクして投げるため、**1 チャンク目(100 ids)が必ず 500** になり、最初の約 100 条文の Like/閲覧数が表示されない。2 チャンク目(20 ids 等)は 200。

## 根因
`MAX_BATCH_SIZE`(=1000) を許可しているのに、batchGet ハンドラが D1 クエリを ids 件数で分割せず、`WHERE service_id IN (?,?,...)` を ids ぶんのプレースホルダで動的構築していた。

Cloudflare D1 (SQLite) は **1 ステートメントあたりバインド変数 100 個まで**（`SQLITE_MAX_VARIABLE_NUMBER = 100`）。
- **like** `likedQuery`: `IN (?×N) AND user_hash=? AND date=? AND action_type=?` → **N+3** バインド。N=97 で 100（OK）、**N=98 で 101 → 上限超過 → 500**。実機の 97/98 境界と一致。
- **visit** `dailyQuery`: `IN (?×N) AND date>=?` → **N+1** バインド。同根。

## 修正
- like / visit 両 batchGet ハンドラ内部で ids を `BATCH_GET_CHUNK_SIZE = 50` に**内部サブチャンク**し、各チャンクの結果を 1 つの map にマージして返す（最重量の like likedQuery でも 53 バインドで上限の半分以下）。
- サブチャンクは**直列実行**（Workers の subrequest 上限と D1 同時接続に対し安全側）。
- 分割ロジックを純粋関数 `chunkArray(ids, size)` に切り出し（`apps/api/src/lib/core/batch.ts`）。
- **レスポンス形は不変**（`{success:true, data:{id:{...}}}`）。読み取りのみ。batchIncrement 等は作らない。

## テスト
`apps/api/src/lib/core/batch.test.ts`（`node:test` + Node v24 type-stripping、ゼロ依存）:
- 98 / 100 / 200 / 1000 件でも **全件を重複なく・順序を保って被覆**することを検証（欠落しない証明）。
- 各チャンクが **D1 の 100 バインド上限を超えない**（like=size+3, visit=size+1）。
- 端数・空配列・不正 size の境界。
- `pnpm --filter @nostalgic/api test` → 10/10 pass。

## 品質ゲート
- typecheck (tsc --noEmit): pass
- lint (eslint): clean
- prettier: clean
- build (web): pass
- wrangler deploy --dry-run: バンドル成功（デプロイはしない）