### PR TITLE
Add service lookup APIs

### DIFF
--- a/apps/api/src/lib/core/auth.ts
+++ b/apps/api/src/lib/core/auth.ts
@@ -1,4 +1,4 @@
-import { hashTokenWithSalt, verifyTokenHash } from "./crypto";
+import { hashTokenWithSalt, verifyTokenHash } from "./crypto.ts";
 
 /**
  * トークンをハッシュ化（PBKDF2 + salt）- async version

--- a/apps/api/src/lib/core/batch.test.ts
+++ b/apps/api/src/lib/core/batch.test.ts
@@ -10,12 +10,19 @@
  * 観点:
  *  - chunkArray が全件を「重複なく・順序を保ったまま」被覆する（batchGet で欠落しない証明）
  *  - 閾値超（98 / 100 / 200 / 1000 件）でも各チャンクが D1 の 100 バインド上限を超えない
- *    （like の likedQuery は chunkSize+3 バインドになるため、その値が 100 未満であること）
+ *    （like の likedQuery は chunkSize+3 バインドになるため、その値が 100 以下であること）
  */
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { chunkArray, BATCH_GET_CHUNK_SIZE } from "./batch.ts";
+import {
+  chunkArray,
+  BATCH_GET_CHUNK_SIZE,
+  D1_BIND_LIMIT,
+  MAX_BATCH_QUERY_FIXED_BINDS,
+} from "./batch.ts";
+
+const TEST_CHUNK_SIZE = 3;
 
 // 連結すると元配列に完全一致する（順序保持 + 全件被覆 + 重複なし）
 function assertCovers<T>(original: readonly T[], chunks: T[][], size: number): void {
@@ -32,30 +39,30 @@ function assertCovers<T>(original: readonly T[], chunks: T[][], size: number): v
 }
 
 test("chunkArray: empty array -> no chunks", () => {
-  assert.deepEqual(chunkArray([], 50), []);
+  assert.deepEqual(chunkArray([], TEST_CHUNK_SIZE), []);
 });
 
 test("chunkArray: fewer than size -> single chunk", () => {
-  const ids = Array.from({ length: 10 }, (_, i) => `id-${i}`);
-  const chunks = chunkArray(ids, 50);
+  const ids = Array.from({ length: TEST_CHUNK_SIZE - 1 }, (_, i) => `id-${i}`);
+  const chunks = chunkArray(ids, TEST_CHUNK_SIZE);
   assert.equal(chunks.length, 1);
-  assertCovers(ids, chunks, 50);
+  assertCovers(ids, chunks, TEST_CHUNK_SIZE);
 });
 
 test("chunkArray: exactly size -> single full chunk", () => {
-  const ids = Array.from({ length: 50 }, (_, i) => `id-${i}`);
-  const chunks = chunkArray(ids, 50);
+  const ids = Array.from({ length: TEST_CHUNK_SIZE }, (_, i) => `id-${i}`);
+  const chunks = chunkArray(ids, TEST_CHUNK_SIZE);
   assert.equal(chunks.length, 1);
-  assertCovers(ids, chunks, 50);
+  assertCovers(ids, chunks, TEST_CHUNK_SIZE);
 });
 
-test("chunkArray: size+1 -> two chunks (50 + 1)", () => {
-  const ids = Array.from({ length: 51 }, (_, i) => `id-${i}`);
-  const chunks = chunkArray(ids, 50);
+test("chunkArray: size+1 -> two chunks", () => {
+  const ids = Array.from({ length: TEST_CHUNK_SIZE + 1 }, (_, i) => `id-${i}`);
+  const chunks = chunkArray(ids, TEST_CHUNK_SIZE);
   assert.equal(chunks.length, 2);
-  assert.equal(chunks[0].length, 50);
+  assert.equal(chunks[0].length, TEST_CHUNK_SIZE);
   assert.equal(chunks[1].length, 1);
-  assertCovers(ids, chunks, 50);
+  assertCovers(ids, chunks, TEST_CHUNK_SIZE);
 });
 
 // 実機で 500 になっていた閾値超のケースを網羅
@@ -71,16 +78,24 @@ for (const total of [98, 100, 200, 1000]) {
 }
 
 test("BATCH_GET_CHUNK_SIZE: 各チャンクは D1 の 100 バインド上限を超えない", () => {
+  assert.equal(
+    BATCH_GET_CHUNK_SIZE,
+    D1_BIND_LIMIT - MAX_BATCH_QUERY_FIXED_BINDS,
+    "chunk size is derived from D1 bind limit and worst-case fixed binds"
+  );
   // like batchGet の likedQuery が最もバインドが多い:
   // IN(...N...) + user_hash + date + action_type = N+3
-  const likeWorstCaseBinds = BATCH_GET_CHUNK_SIZE + 3;
+  const likeWorstCaseBinds = BATCH_GET_CHUNK_SIZE + MAX_BATCH_QUERY_FIXED_BINDS;
   assert.ok(
-    likeWorstCaseBinds < 100,
-    `like worst-case binds (${likeWorstCaseBinds}) must stay under SQLite limit 100`
+    likeWorstCaseBinds <= D1_BIND_LIMIT,
+    `like worst-case binds (${likeWorstCaseBinds}) must stay within SQLite limit ${D1_BIND_LIMIT}`
   );
   // visit batchGet の dailyQuery: IN(...N...) + monthStart = N+1
   const visitBinds = BATCH_GET_CHUNK_SIZE + 1;
-  assert.ok(visitBinds < 100, `visit dailyQuery binds (${visitBinds}) must stay under 100`);
+  assert.ok(
+    visitBinds <= D1_BIND_LIMIT,
+    `visit dailyQuery binds (${visitBinds}) must stay within ${D1_BIND_LIMIT}`
+  );
 });
 
 test("chunkArray: size が不正なら例外", () => {

--- a/apps/api/src/lib/core/batch.ts
+++ b/apps/api/src/lib/core/batch.ts
@@ -1,7 +1,7 @@
 /**
  * Batch utilities
  *
- * D1 (SQLite) は 1 ステートメントあたりのバインド変数を 100 個までしか許可しない
+ * D1 (SQLite) は 1 ステートメントあたりのバインド変数を D1_BIND_LIMIT 個までしか許可しない
  * (SQLITE_MAX_VARIABLE_NUMBER = 100)。batchGet は `WHERE service_id IN (?,?,...)`
  * を組み立てるため、ids が ~98 件を超えると bind 変数が 100 を超えて D1 が 500 を返す。
  *
@@ -15,12 +15,16 @@
  */
 
 /**
- * batchGet の内部 D1 サブチャンクサイズ。
+ * D1 の内部サブチャンクサイズ。
  *
- * 最もバインドの多いクエリ（like の likedQuery: N+3 バインド）でも
- * 50+3=53 と 100 の半分以下に収め、固定列が増えても安全マージンを残す。
+ * 最もバインドの多い batch クエリ（like の likedQuery）は、ID の IN 句に加えて
+ * user_hash / date / action_type の 3 固定 bind を使う。公開 API 上限とは別に、
+ * 1 SQL statement が D1_BIND_LIMIT を超えないよう、ここから機械的に算出する。
  */
-export const BATCH_GET_CHUNK_SIZE = 50;
+export const D1_BIND_LIMIT = 100;
+export const MAX_BATCH_QUERY_FIXED_BINDS = 3;
+export const D1_BATCH_CHUNK_SIZE = D1_BIND_LIMIT - MAX_BATCH_QUERY_FIXED_BINDS;
+export const BATCH_GET_CHUNK_SIZE = D1_BATCH_CHUNK_SIZE;
 
 /**
  * 配列を指定サイズのチャンクに分割する純粋関数。

--- a/apps/api/src/lib/core/lookup.test.ts
+++ b/apps/api/src/lib/core/lookup.test.ts
@@ -1,0 +1,320 @@
+/**
+ * lookup.ts のユニットテスト
+ *
+ * D1 の最小 fake を使い、BBS / Ranking / Yokoso の URL owner lookup が
+ * 順序保持・重複保持・missing/invalid token を正規形で返すことを確認する。
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { sha256 } from "./crypto.ts";
+import {
+  batchLookupServices,
+  lookupService,
+  MAX_LOOKUP_BATCH_SIZE,
+  type LookupServiceType,
+} from "./lookup.ts";
+import { BATCH_GET_CHUNK_SIZE } from "./batch.ts";
+
+type ServiceRow = {
+  id: string;
+  type: LookupServiceType;
+  url: string;
+  serviceId: string;
+  metadata?: string | null;
+  tokenHash?: string;
+};
+
+class FakeStatement {
+  db: FakeD1Database;
+  sql: string;
+
+  constructor(db: FakeD1Database, sql: string) {
+    this.db = db;
+    this.sql = sql;
+  }
+
+  bind(...values: unknown[]) {
+    this.db.bindCalls.push(values);
+    return {
+      all: async <T>() => ({ results: this.db.query<T>(this.sql, values) }),
+    };
+  }
+}
+
+class FakeD1Database {
+  bindCalls: unknown[][] = [];
+  rows: ServiceRow[];
+
+  constructor(rows: ServiceRow[]) {
+    this.rows = rows;
+  }
+
+  prepare(sql: string) {
+    return new FakeStatement(this, sql);
+  }
+
+  query<T>(sql: string, values: unknown[]): T[] {
+    if (sql.includes("FROM url_mappings")) {
+      const [type, _joinType, ...urls] = values as [
+        LookupServiceType,
+        LookupServiceType,
+        ...string[],
+      ];
+      return this.rows
+        .filter((row) => row.type === type && urls.includes(row.url))
+        .map((row) => ({
+          url: row.url,
+          public_id: row.id,
+          service_id: row.serviceId,
+          metadata: row.metadata,
+        })) as T[];
+    }
+
+    if (sql.includes("FROM owner_tokens")) {
+      const serviceIds = values as string[];
+      return this.rows
+        .filter((row) => row.tokenHash && serviceIds.includes(row.serviceId))
+        .map((row) => ({
+          service_id: row.serviceId,
+          token_hash: row.tokenHash,
+        })) as T[];
+    }
+
+    throw new Error(`Unexpected query: ${sql}`);
+  }
+}
+
+async function makeDb(): Promise<FakeD1Database> {
+  const valid = await sha256("valid-token");
+  const other = await sha256("other-token");
+  return new FakeD1Database([
+    {
+      id: "bbs-a1",
+      type: "bbs",
+      url: "https://a.example/post/",
+      serviceId: "bbs:bbs-a1",
+      metadata: JSON.stringify({ title: "Comments" }),
+      tokenHash: valid,
+    },
+    {
+      id: "ranking-a1",
+      type: "ranking",
+      url: "https://a.example/post/",
+      serviceId: "ranking:ranking-a1",
+      metadata: JSON.stringify({ title: "High Score" }),
+      tokenHash: other,
+    },
+    {
+      id: "yokoso-a1",
+      type: "yokoso",
+      url: "https://welcome.example/",
+      serviceId: "yokoso:yokoso-a1",
+      metadata: JSON.stringify({ message: "Welcome!" }),
+      tokenHash: valid,
+    },
+    {
+      id: "bbs-bad-json",
+      type: "bbs",
+      url: "https://bad-json.example/",
+      serviceId: "bbs:bbs-bad-json",
+      metadata: "{",
+      tokenHash: valid,
+    },
+    {
+      id: "bbs-no-token",
+      type: "bbs",
+      url: "https://no-token.example/",
+      serviceId: "bbs:bbs-no-token",
+      metadata: JSON.stringify({ title: "No Token" }),
+    },
+  ]);
+}
+
+test("lookupService: found authorized service returns id and title", async () => {
+  const db = await makeDb();
+  const result = await lookupService(
+    db as unknown as D1Database,
+    "bbs",
+    "https://a.example/post/",
+    "valid-token"
+  );
+
+  assert.deepEqual(result, {
+    url: "https://a.example/post/",
+    exists: true,
+    authorized: true,
+    id: "bbs-a1",
+    title: "Comments",
+  });
+});
+
+test("lookupService: missing URL returns exists false", async () => {
+  const db = await makeDb();
+  const result = await lookupService(
+    db as unknown as D1Database,
+    "bbs",
+    "https://missing.example/",
+    "valid-token"
+  );
+
+  assert.deepEqual(result, {
+    url: "https://missing.example/",
+    exists: false,
+  });
+});
+
+test("lookupService: invalid token is item-level unauthorized without id/title", async () => {
+  const db = await makeDb();
+  const result = await lookupService(
+    db as unknown as D1Database,
+    "bbs",
+    "https://a.example/post/",
+    "wrong-token"
+  );
+
+  assert.deepEqual(result, {
+    url: "https://a.example/post/",
+    exists: true,
+    authorized: false,
+    id: undefined,
+    title: undefined,
+  });
+});
+
+test("lookupService: service type is isolated by URL mapping type", async () => {
+  const db = await makeDb();
+  const result = await lookupService(
+    db as unknown as D1Database,
+    "ranking",
+    "https://a.example/post/",
+    "valid-token"
+  );
+
+  assert.deepEqual(result, {
+    url: "https://a.example/post/",
+    exists: true,
+    authorized: false,
+    id: undefined,
+    title: undefined,
+  });
+});
+
+test("lookupService: missing owner token row is unauthorized", async () => {
+  const db = await makeDb();
+  const result = await lookupService(
+    db as unknown as D1Database,
+    "bbs",
+    "https://no-token.example/",
+    "valid-token"
+  );
+
+  assert.deepEqual(result, {
+    url: "https://no-token.example/",
+    exists: true,
+    authorized: false,
+    id: undefined,
+    title: undefined,
+  });
+});
+
+test("lookupService: malformed metadata does not crash", async () => {
+  const db = await makeDb();
+  const result = await lookupService(
+    db as unknown as D1Database,
+    "bbs",
+    "https://bad-json.example/",
+    "valid-token"
+  );
+
+  assert.deepEqual(result, {
+    url: "https://bad-json.example/",
+    exists: true,
+    authorized: true,
+    id: "bbs-bad-json",
+    title: undefined,
+  });
+});
+
+test("lookupService: Yokoso returns fixed title without exposing message", async () => {
+  const db = await makeDb();
+  const result = await lookupService(
+    db as unknown as D1Database,
+    "yokoso",
+    "https://welcome.example/",
+    "valid-token"
+  );
+
+  assert.deepEqual(result, {
+    url: "https://welcome.example/",
+    exists: true,
+    authorized: true,
+    id: "yokoso-a1",
+    title: "Yokoso",
+  });
+});
+
+test("batchLookupServices: preserves order, duplicates, and mixed results", async () => {
+  const db = await makeDb();
+  const result = await batchLookupServices(
+    db as unknown as D1Database,
+    "bbs",
+    [
+      "https://missing.example/",
+      "https://a.example/post/",
+      "https://a.example/post/",
+      "https://no-token.example/",
+    ],
+    "valid-token"
+  );
+
+  assert.deepEqual(result, [
+    { url: "https://missing.example/", exists: false },
+    {
+      url: "https://a.example/post/",
+      exists: true,
+      authorized: true,
+      id: "bbs-a1",
+      title: "Comments",
+    },
+    {
+      url: "https://a.example/post/",
+      exists: true,
+      authorized: true,
+      id: "bbs-a1",
+      title: "Comments",
+    },
+    {
+      url: "https://no-token.example/",
+      exists: true,
+      authorized: false,
+      id: undefined,
+      title: undefined,
+    },
+  ]);
+});
+
+test("batchLookupServices: chunks URL and token queries under D1 bind limit", async () => {
+  const valid = await sha256("valid-token");
+  const rows = Array.from({ length: MAX_LOOKUP_BATCH_SIZE }, (_, i) => ({
+    id: `bbs-${i}`,
+    type: "bbs" as const,
+    url: `https://example.com/${i}`,
+    serviceId: `bbs:bbs-${i}`,
+    metadata: JSON.stringify({ title: `Comments ${i}` }),
+    tokenHash: valid,
+  }));
+  const db = new FakeD1Database(rows);
+  const urls = rows.map((row) => row.url);
+  const result = await batchLookupServices(db as unknown as D1Database, "bbs", urls, "valid-token");
+
+  assert.equal(result.length, MAX_LOOKUP_BATCH_SIZE);
+  assert.equal(
+    result.every((item) => item.exists && item.authorized),
+    true
+  );
+  for (const values of db.bindCalls) {
+    assert.ok(values.length <= BATCH_GET_CHUNK_SIZE + 2, "URL lookup bind count stays chunked");
+    assert.ok(values.length <= 100, "D1 bind count stays under 100");
+  }
+});

--- a/apps/api/src/lib/core/lookup.ts
+++ b/apps/api/src/lib/core/lookup.ts
@@ -1,0 +1,122 @@
+import { verifyToken } from "./auth.ts";
+import { BATCH_GET_CHUNK_SIZE, chunkArray } from "./batch.ts";
+
+export type LookupServiceType = "bbs" | "ranking" | "yokoso";
+export const MAX_LOOKUP_BATCH_SIZE = 1000;
+
+export type LookupResult = {
+  url: string;
+  exists: boolean;
+  id?: string;
+  title?: string;
+  authorized?: boolean;
+};
+
+type LookupRow = {
+  url: string;
+  public_id: string;
+  service_id: string;
+  metadata?: string | null;
+};
+
+type TokenRow = {
+  service_id: string;
+  token_hash: string;
+};
+
+function defaultTitle(type: LookupServiceType): string | undefined {
+  return type === "yokoso" ? "Yokoso" : undefined;
+}
+
+function extractTitle(
+  type: LookupServiceType,
+  metadata: string | null | undefined
+): string | undefined {
+  if (!metadata) return undefined;
+  try {
+    const parsed = JSON.parse(metadata) as { title?: unknown };
+    return typeof parsed.title === "string" ? parsed.title : defaultTitle(type);
+  } catch {
+    return defaultTitle(type);
+  }
+}
+
+export async function batchLookupServices(
+  db: D1Database,
+  type: LookupServiceType,
+  urls: readonly string[],
+  token: string
+): Promise<LookupResult[]> {
+  // Public batchLookup accepts up to MAX_LOOKUP_BATCH_SIZE URLs. The chunks below
+  // are only for D1/SQLite bind limits inside each SQL statement.
+  const uniqueUrls = [...new Set(urls)];
+  const rowsByUrl = new Map<string, LookupRow>();
+
+  for (const urlChunk of chunkArray(uniqueUrls, BATCH_GET_CHUNK_SIZE)) {
+    if (urlChunk.length === 0) continue;
+    const placeholders = urlChunk.map(() => "?").join(",");
+    const { results } = await db
+      .prepare(
+        `
+        SELECT m.url, m.service_id AS public_id, s.id AS service_id, s.metadata
+        FROM url_mappings m
+        JOIN services s ON s.id = ? || ':' || m.service_id
+        WHERE m.type = ? AND m.url IN (${placeholders})
+      `
+      )
+      .bind(type, type, ...urlChunk)
+      .all<LookupRow>();
+
+    for (const row of results) {
+      rowsByUrl.set(row.url, row);
+    }
+  }
+
+  const serviceIds = [...new Set([...rowsByUrl.values()].map((row) => row.service_id))];
+  const authorizedByServiceId = new Map<string, boolean>();
+
+  for (const idChunk of chunkArray(serviceIds, BATCH_GET_CHUNK_SIZE)) {
+    if (idChunk.length === 0) continue;
+    const placeholders = idChunk.map(() => "?").join(",");
+    const { results } = await db
+      .prepare(
+        `
+        SELECT service_id, token_hash
+        FROM owner_tokens
+        WHERE service_id IN (${placeholders})
+      `
+      )
+      .bind(...idChunk)
+      .all<TokenRow>();
+
+    for (const row of results) {
+      authorizedByServiceId.set(row.service_id, await verifyToken(token, row.token_hash));
+    }
+  }
+
+  return urls.map((url) => {
+    const row = rowsByUrl.get(url);
+    if (!row) {
+      return { url, exists: false };
+    }
+
+    const authorized = authorizedByServiceId.get(row.service_id) === true;
+    return {
+      url,
+      exists: true,
+      authorized,
+      id: authorized ? row.public_id : undefined,
+      title: authorized ? extractTitle(type, row.metadata) : undefined,
+    };
+  });
+}
+
+export async function lookupService(
+  db: D1Database,
+  type: LookupServiceType,
+  url: string,
+  token: string
+): Promise<LookupResult> {
+  const [result] = await batchLookupServices(db, type, [url], token);
+  return result;
+}

--- a/apps/api/src/routes/bbs.ts
+++ b/apps/api/src/routes/bbs.ts
@@ -3,6 +3,8 @@
  *
  * GET  /?action=get     - Public read (by id)
  * POST /?action=get     - Owner read (body: url, token) - token never in URL
+ * POST /?action=lookup  - Owner URL lookup (body: url, token) - lightweight id check
+ * POST /?action=batchLookup - Owner URL lookup (body: urls, token) - ordered lightweight id checks
  * POST /?action=create  - Create a new BBS (body: url, token, ...)
  * POST /?action=post    - Post a message (body: id, message, author?, ...)
  * POST /?action=update  - Update settings or message (body: url+token or id+messageId)
@@ -17,6 +19,7 @@ import { generatePublicId } from "../lib/core/id";
 import { generateUserHash } from "../lib/core/crypto";
 import { BBS } from "../lib/core/constants";
 import { sendWebHook, WebHookMessages } from "../lib/core/webhook";
+import { batchLookupServices, lookupService, MAX_LOOKUP_BATCH_SIZE } from "../lib/core/lookup";
 
 type Bindings = { DB: D1Database };
 
@@ -193,6 +196,38 @@ app.post("/", async (c) => {
     if (typeof val === "string") return val;
     return undefined;
   };
+
+  // LOOKUP (owner URL lookup - lightweight id check, no messages/settings payload)
+  if (action === "lookup") {
+    const url = getParam("url");
+    const token = getSecureParam("token");
+
+    if (!url || !token) {
+      return c.json({ error: "url and token are required for lookup" }, 400);
+    }
+
+    const data = await lookupService(db, "bbs", url, token);
+    return c.json({ success: true, data });
+  }
+
+  // BATCH LOOKUP (ordered owner URL lookup - no messages/settings payload)
+  if (action === "batchLookup") {
+    const urls = body.urls;
+    const token = getSecureParam("token");
+
+    if (!Array.isArray(urls) || urls.some((url) => typeof url !== "string")) {
+      return c.json({ error: "urls must be an array of strings" }, 400);
+    }
+    if (urls.length > MAX_LOOKUP_BATCH_SIZE) {
+      return c.json({ error: `Maximum ${MAX_LOOKUP_BATCH_SIZE} urls per request` }, 400);
+    }
+    if (!token) {
+      return c.json({ error: "token is required for batchLookup" }, 400);
+    }
+
+    const data = await batchLookupServices(db, "bbs", urls, token);
+    return c.json({ success: true, data });
+  }
 
   // GET (owner mode - token in body, not URL)
   if (action === "get") {
@@ -712,7 +747,7 @@ app.post("/", async (c) => {
   return c.json(
     {
       error:
-        "Invalid action for POST. Use: get (owner), create, post, update, remove, clear, delete",
+        "Invalid action for POST. Use: lookup, batchLookup, get (owner), create, post, update, remove, clear, delete",
     },
     400
   );

--- a/apps/api/src/routes/ranking.ts
+++ b/apps/api/src/routes/ranking.ts
@@ -3,6 +3,8 @@
  *
  * GET  /?action=get     - Public read (by id)
  * POST /?action=get     - Owner read (body: url, token) - token never in URL
+ * POST /?action=lookup  - Owner URL lookup (body: url, token) - lightweight id check
+ * POST /?action=batchLookup - Owner URL lookup (body: urls, token) - ordered lightweight id checks
  * POST /?action=create  - Create a new ranking (body: url, token, ...)
  * POST /?action=submit  - Submit a score (body: id, score, name?, displayScore?)
  * POST /?action=update  - Update settings (body: url, token, ...)
@@ -17,6 +19,7 @@ import { generatePublicId } from "../lib/core/id";
 import { generateUserHash } from "../lib/core/crypto";
 import { RANKING } from "../lib/core/constants";
 import { sendWebHook, WebHookMessages } from "../lib/core/webhook";
+import { batchLookupServices, lookupService, MAX_LOOKUP_BATCH_SIZE } from "../lib/core/lookup";
 
 type Bindings = { DB: D1Database };
 
@@ -193,6 +196,38 @@ app.post("/", async (c) => {
     if (typeof val === "string") return val;
     return undefined;
   };
+
+  // LOOKUP (owner URL lookup - lightweight id check, no entries/settings payload)
+  if (action === "lookup") {
+    const url = getParam("url");
+    const token = getSecureParam("token");
+
+    if (!url || !token) {
+      return c.json({ error: "url and token are required for lookup" }, 400);
+    }
+
+    const data = await lookupService(db, "ranking", url, token);
+    return c.json({ success: true, data });
+  }
+
+  // BATCH LOOKUP (ordered owner URL lookup - no entries/settings payload)
+  if (action === "batchLookup") {
+    const urls = body.urls;
+    const token = getSecureParam("token");
+
+    if (!Array.isArray(urls) || urls.some((url) => typeof url !== "string")) {
+      return c.json({ error: "urls must be an array of strings" }, 400);
+    }
+    if (urls.length > MAX_LOOKUP_BATCH_SIZE) {
+      return c.json({ error: `Maximum ${MAX_LOOKUP_BATCH_SIZE} urls per request` }, 400);
+    }
+    if (!token) {
+      return c.json({ error: "token is required for batchLookup" }, 400);
+    }
+
+    const data = await batchLookupServices(db, "ranking", urls, token);
+    return c.json({ success: true, data });
+  }
 
   // GET (owner mode - token in body, not URL)
   if (action === "get") {
@@ -591,7 +626,7 @@ app.post("/", async (c) => {
   return c.json(
     {
       error:
-        "Invalid action for POST. Use: get (owner), create, submit, update, remove, clear, delete",
+        "Invalid action for POST. Use: lookup, batchLookup, get (owner), create, submit, update, remove, clear, delete",
     },
     400
   );

--- a/apps/api/src/routes/yokoso.ts
+++ b/apps/api/src/routes/yokoso.ts
@@ -4,6 +4,8 @@
  *
  * GET  /?action=get     - Public read (by id)
  * POST /?action=get     - Owner read (body: url, token) - token never in URL
+ * POST /?action=lookup  - Owner URL lookup (body: url, token) - lightweight id check
+ * POST /?action=batchLookup - Owner URL lookup (body: urls, token) - ordered lightweight id checks
  * POST /?action=create  - Create a new yokoso (body: url, token, message, ...)
  * POST /?action=update  - Update message/settings (body: url, token, ...)
  * POST /?action=delete  - Delete yokoso (body: url, token)
@@ -14,6 +16,7 @@ import { hashToken, verifyToken, validateOwnerToken } from "../lib/core/auth";
 import { generatePublicId } from "../lib/core/id";
 import { sendWebHook, WebHookMessages } from "../lib/core/webhook";
 import { LUCKY_CAT_DATA_URL } from "../assets/lucky-cat";
+import { batchLookupServices, lookupService, MAX_LOOKUP_BATCH_SIZE } from "../lib/core/lookup";
 
 type Bindings = { DB: D1Database };
 
@@ -385,6 +388,38 @@ app.post("/", async (c) => {
     return undefined;
   };
 
+  // LOOKUP (owner URL lookup - lightweight id check, no message/settings payload)
+  if (action === "lookup") {
+    const url = getParam("url");
+    const token = getSecureParam("token");
+
+    if (!url || !token) {
+      return c.json({ error: "url and token are required for lookup" }, 400);
+    }
+
+    const data = await lookupService(db, "yokoso", url, token);
+    return c.json({ success: true, data });
+  }
+
+  // BATCH LOOKUP (ordered owner URL lookup - no message/settings payload)
+  if (action === "batchLookup") {
+    const urls = body.urls;
+    const token = getSecureParam("token");
+
+    if (!Array.isArray(urls) || urls.some((url) => typeof url !== "string")) {
+      return c.json({ error: "urls must be an array of strings" }, 400);
+    }
+    if (urls.length > MAX_LOOKUP_BATCH_SIZE) {
+      return c.json({ error: `Maximum ${MAX_LOOKUP_BATCH_SIZE} urls per request` }, 400);
+    }
+    if (!token) {
+      return c.json({ error: "token is required for batchLookup" }, 400);
+    }
+
+    const data = await batchLookupServices(db, "yokoso", urls, token);
+    return c.json({ success: true, data });
+  }
+
   // GET (owner mode - token in body, not URL)
   if (action === "get") {
     const url = getParam("url");
@@ -629,7 +664,10 @@ app.post("/", async (c) => {
   }
 
   return c.json(
-    { error: "Invalid action for POST. Use: get (owner), create, update, delete" },
+    {
+      error:
+        "Invalid action for POST. Use: lookup, batchLookup, get (owner), create, update, delete",
+    },
     400
   );
 });

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -12,6 +12,7 @@
     "rootDir": "src",
     "resolveJsonModule": true,
     "isolatedModules": true,
+    "allowImportingTsExtensions": true,
     "noEmit": true
   },
   "include": ["src/**/*"],

--- a/apps/web/src/config/services/bbsSteps.tsx
+++ b/apps/web/src/config/services/bbsSteps.tsx
@@ -184,19 +184,21 @@ const confirmIdStep: StepConfig = {
   isOwnerStep: true,
   fields: [COMMON_FIELDS.url, COMMON_FIELDS.token],
   buttonText: "公開ID確認",
-  handlerKey: "handleCreate",
-  responseKey: "createResponse",
-  buildApiUrl: (values) => {
-    const url = values.url || "サイトURL";
-    const token = values.token || "オーナートークン";
-    return `${API_BASE}${ENDPOINT}?action=create&url=${encodeURIComponent(url)}&token=${encodeURIComponent(token)}`;
+  handlerKey: "handleLookup",
+  responseKey: "lookupResponse",
+  buildApiUrl: (_values) => {
+    return `${API_BASE}${ENDPOINT}?action=lookup`;
   },
   buildApiUrlDisplay: (values) => (
     <>
-      {API_BASE}
-      {ENDPOINT}?action=create&url=
+      POST {API_BASE}
+      {ENDPOINT}?action=lookup
+      <br />
+      Body: {'{ "url": "'}
       <GreenParam>{values.url || "サイトURL"}</GreenParam>
-      &token=<GreenParam>{values.token || "オーナートークン"}</GreenParam>
+      {'", "token": "'}
+      <GreenParam>{values.token || "オーナートークン"}</GreenParam>
+      {'" }'}
     </>
   ),
 };

--- a/apps/web/src/config/services/rankingSteps.tsx
+++ b/apps/web/src/config/services/rankingSteps.tsx
@@ -166,19 +166,21 @@ const confirmIdStep: StepConfig = {
   isOwnerStep: true,
   fields: [COMMON_FIELDS.url, COMMON_FIELDS.token],
   buttonText: "公開ID確認",
-  handlerKey: "handleCreate",
-  responseKey: "createResponse",
-  buildApiUrl: (values) => {
-    const url = values.url || "サイトURL";
-    const token = values.token || "オーナートークン";
-    return `${API_BASE}${ENDPOINT}?action=create&url=${encodeURIComponent(url)}&token=${encodeURIComponent(token)}`;
+  handlerKey: "handleLookup",
+  responseKey: "lookupResponse",
+  buildApiUrl: (_values) => {
+    return `${API_BASE}${ENDPOINT}?action=lookup`;
   },
   buildApiUrlDisplay: (values) => (
     <>
-      {API_BASE}
-      {ENDPOINT}?action=create&url=
+      POST {API_BASE}
+      {ENDPOINT}?action=lookup
+      <br />
+      Body: {'{ "url": "'}
       <GreenParam>{values.url || "サイトURL"}</GreenParam>
-      &token=<GreenParam>{values.token || "オーナートークン"}</GreenParam>
+      {'", "token": "'}
+      <GreenParam>{values.token || "オーナートークン"}</GreenParam>
+      {'" }'}
     </>
   ),
 };

--- a/apps/web/src/config/services/yokosoSteps.tsx
+++ b/apps/web/src/config/services/yokosoSteps.tsx
@@ -200,6 +200,32 @@ const getStep: StepConfig = {
   ),
 };
 
+// Confirm Public ID step
+const confirmIdStep: StepConfig = {
+  id: "confirmId",
+  title: "◆公開IDを再確認したいときは？◆",
+  isOwnerStep: true,
+  fields: [COMMON_FIELDS.url, COMMON_FIELDS.token],
+  buttonText: "公開ID確認",
+  handlerKey: "handleLookup",
+  responseKey: "lookupResponse",
+  buildApiUrl: (_values) => {
+    return `${API_BASE}${ENDPOINT}?action=lookup`;
+  },
+  buildApiUrlDisplay: (values) => (
+    <>
+      POST {API_BASE}
+      {ENDPOINT}?action=lookup
+      <br />
+      Body: {'{ "url": "'}
+      <GreenParam>{values.url || "サイトURL"}</GreenParam>
+      {'", "token": "'}
+      <GreenParam>{values.token || "オーナートークン"}</GreenParam>
+      {'" }'}
+    </>
+  ),
+};
+
 // Delete step
 const deleteStep: StepConfig = {
   id: "delete",
@@ -235,5 +261,6 @@ export const yokosoSteps: StepConfig[] = [
   displayStep,
   updateMessageStep,
   getStep,
+  confirmIdStep,
   deleteStep,
 ];

--- a/apps/web/src/hooks/useFetchApi.ts
+++ b/apps/web/src/hooks/useFetchApi.ts
@@ -3,10 +3,10 @@ import { useState } from "react";
 export type ResponseType = "json" | "text" | "svg";
 
 /**
- * Mutating actions that must use POST instead of GET.
- * Tokens and sensitive data are sent in the request body, not URL.
+ * Actions that must use POST instead of GET.
+ * Owner tokens stay in the request body, and batch payloads do not fit URL-first GET cleanly.
  */
-const MUTATING_ACTIONS = new Set([
+const POST_ACTIONS = new Set([
   "create",
   "update",
   "set",
@@ -18,12 +18,14 @@ const MUTATING_ACTIONS = new Set([
   "clear",
   "batchCreate",
   "batchGet",
+  "lookup",
+  "batchLookup",
 ]);
 
-function isMutatingAction(url: string): boolean {
+function shouldUsePost(url: string): boolean {
   const urlObj = new URL(url, window.location.origin);
   const action = urlObj.searchParams.get("action");
-  return action !== null && MUTATING_ACTIONS.has(action);
+  return action !== null && POST_ACTIONS.has(action);
 }
 
 /**
@@ -69,7 +71,7 @@ export default function useFetchApi(initialType: ResponseType = "json"): UseFetc
     try {
       let res: Response;
 
-      if (isMutatingAction(url)) {
+      if (shouldUsePost(url)) {
         const { cleanUrl, bodyParams } = extractBodyParams(url);
         res = await fetch(cleanUrl, {
           method: "POST",

--- a/apps/web/src/pages/BBS.tsx
+++ b/apps/web/src/pages/BBS.tsx
@@ -68,6 +68,7 @@ export default function BBSPage() {
 
   // Response state
   const [createResponse, setCreateResponse] = useState("");
+  const [lookupResponse, setLookupResponse] = useState("");
   const [postResponse, setPostResponse] = useState("");
   const [getResponse, setGetResponse] = useState("");
   const [updateResponse, setUpdateResponse] = useState("");
@@ -125,6 +126,14 @@ export default function BBSPage() {
     if (webhookUrl) apiUrl += `&webhookUrl=${encodeURIComponent(webhookUrl)}`;
 
     await callApi(apiUrl, setCreateResponse, setPublicId);
+  };
+
+  const handleLookup = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!url || !token) return;
+
+    const apiUrl = `/api/bbs?action=lookup&url=${encodeURIComponent(url)}&token=${encodeURIComponent(token)}`;
+    await callApi(apiUrl, setLookupResponse, setPublicId);
   };
 
   const handlePost = async (e: React.FormEvent) => {
@@ -220,6 +229,7 @@ export default function BBSPage() {
 
   const handlers = {
     handleCreate,
+    handleLookup,
     handlePost,
     handleGet,
     handleUpdate,
@@ -233,6 +243,7 @@ export default function BBSPage() {
 
   const responses = {
     createResponse,
+    lookupResponse,
     postResponse,
     getResponse,
     updateResponse,

--- a/apps/web/src/pages/Ranking.tsx
+++ b/apps/web/src/pages/Ranking.tsx
@@ -46,6 +46,7 @@ export default function RankingPage() {
 
   // Response state
   const [createResponse, setCreateResponse] = useState("");
+  const [lookupResponse, setLookupResponse] = useState("");
   const [submitResponse, setSubmitResponse] = useState("");
   const [getResponse, setGetResponse] = useState("");
   const [updateResponse, setUpdateResponse] = useState("");
@@ -91,6 +92,14 @@ export default function RankingPage() {
     if (webhookUrl) apiUrl += `&webhookUrl=${encodeURIComponent(webhookUrl)}`;
 
     await callApi(apiUrl, setCreateResponse, setPublicId);
+  };
+
+  const handleLookup = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!url || !token) return;
+
+    const apiUrl = `/api/ranking?action=lookup&url=${encodeURIComponent(url)}&token=${encodeURIComponent(token)}`;
+    await callApi(apiUrl, setLookupResponse, setPublicId);
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -160,6 +169,7 @@ export default function RankingPage() {
 
   const handlers = {
     handleCreate,
+    handleLookup,
     handleSubmit,
     handleGet,
     handleUpdate,
@@ -171,6 +181,7 @@ export default function RankingPage() {
 
   const responses = {
     createResponse,
+    lookupResponse,
     submitResponse,
     getResponse,
     updateResponse,

--- a/apps/web/src/pages/Yokoso.tsx
+++ b/apps/web/src/pages/Yokoso.tsx
@@ -26,6 +26,7 @@ export default function YokosoPage() {
 
   // Response state
   const [createResponse, setCreateResponse] = useState("");
+  const [lookupResponse, setLookupResponse] = useState("");
   const [displayResponse, setDisplayResponse] = useState("");
   const [updateResponse, setUpdateResponse] = useState("");
   const [getResponse, setGetResponse] = useState("");
@@ -60,6 +61,14 @@ export default function YokosoPage() {
     if (webhookUrl) apiUrl += `&webhookUrl=${encodeURIComponent(webhookUrl)}`;
 
     await callApi(apiUrl, setCreateResponse, setPublicId);
+  };
+
+  const handleLookup = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!url || !token) return;
+
+    const apiUrl = `/api/yokoso?action=lookup&url=${encodeURIComponent(url)}&token=${encodeURIComponent(token)}`;
+    await callApi(apiUrl, setLookupResponse, setPublicId);
   };
 
   const handleDisplay = async (e: React.FormEvent) => {
@@ -106,6 +115,7 @@ export default function YokosoPage() {
 
   const handlers = {
     handleCreate,
+    handleLookup,
     handleDisplay,
     handleUpdate,
     handleGet,
@@ -114,6 +124,7 @@ export default function YokosoPage() {
 
   const responses = {
     createResponse,
+    lookupResponse,
     displayResponse,
     updateResponse,
     getResponse,

--- a/apps/web/src/utils/apiHelpers.ts
+++ b/apps/web/src/utils/apiHelpers.ts
@@ -20,8 +20,8 @@ function translateApiResponse(jsonResponse: Record<string, unknown>): Record<str
 
 /**
  * Determine if a request should use POST instead of GET.
- * This includes mutating operations AND any request containing a token
- * (to prevent token exposure in URLs/logs).
+ * This includes mutating operations, owner-token requests, and batch payloads
+ * that do not fit URL-first GET cleanly.
  */
 function shouldUsePost(url: string): boolean {
   const urlObj = new URL(url, window.location.origin);
@@ -44,6 +44,8 @@ function shouldUsePost(url: string): boolean {
     "clear",
     "batchCreate",
     "batchGet",
+    "lookup",
+    "batchLookup",
   ];
   return action !== null && postActions.includes(action);
 }

--- a/docs/user-guide/api.md
+++ b/docs/user-guide/api.md
@@ -6,23 +6,28 @@ Nostalgic is a comprehensive platform that recreates nostalgic web tools (Counte
 
 ## API Architecture
 
-All services use the same URL pattern with action parameters using **GET requests** (with one exception):
+All services use the same URL pattern with action parameters. Public reads use **GET**.
+Owner actions use **POST** with parameters in the JSON body so owner tokens are not exposed in URLs:
 
 ```
-/api/{service}?action={action}&url={your-site}&token={your-token}&...params
+GET  /api/{service}?action=get&id={public-id}
+POST /api/{service}?action={owner-action}
+Body: { "url": "https://your-site.example", "token": "your-token", "...": "..." }
 ```
 
 ### 🌐 Why GET-based? 1990s Web Culture Revival
 
-Just like the original 1990s web tools, everything can be operated directly from the browser URL bar:
+Just like the original 1990s web tools, public display and interaction URLs stay simple enough to paste into a browser, an image tag, or a README:
 
-1. **Click-to-create**: Share a link and instantly create services
-2. **URL-based operations**: All actions are simple GET links
+1. **URL-based public reads**: Public display URLs stay simple GET links
+2. **Embeddable images**: Counter, Like, BBS, and Yokoso images can be used directly in HTML and Markdown
 3. **Nostalgic simplicity**: No complex forms needed
-4. **Easy sharing**: Every operation is a shareable URL
+4. **Easy sharing**: Public actions remain shareable URLs
 5. **BBS culture**: Even message posting uses GET parameters, just like the old days
 
-> **Note**: `batchGet` and `batchCreate` use POST to handle large request bodies that exceed URL length limits. This applies to both Counter and Like services.
+> **Note**: Owner actions use POST so owner tokens are not left in URLs. `batchGet`, `batchCreate`, and `batchLookup` also use POST because they carry arrays that do not fit Nostalgic's URL-first shape cleanly. BBS, Ranking, and Yokoso intentionally use lightweight `lookup` / `batchLookup` instead of heavy `batchGet`: `get` reads service content/settings, while `lookup` only checks URL ownership and returns the generated public ID.
+
+`batchLookup` accepts up to 1000 URLs per request. Internally, Nostalgic may split SQL statements into smaller chunks to stay under D1/SQLite bind-variable limits; this is not a client-visible 100 item API limit, and it is separate from response-size concerns.
 
 ## Services
 
@@ -73,6 +78,7 @@ All services support webhook functionality for real-time event notifications:
 1. **Create**: URL + token → returns public ID
 2. **Use**: Public ID for display/interaction
 3. **Manage**: URL + token for owner operations
+4. **Lookup**: URL + token → exists/id without loading service content
 
 ## Try the Demos
 

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -49,6 +49,7 @@ APIを直接触らずに、すべての機能を試せます。
 - 自動ソート（昇順/降順）
 - 最大エントリー数制限
 - フォーマット済みスコア表示
+- URL owner lookup / batchLookup 対応
 
 ### [6. BBS（掲示板）](./services/bbs.md)
 
@@ -57,6 +58,7 @@ APIを直接触らずに、すべての機能を試せます。
 - 投稿時のオプションフィールド（アイコン、セレクト）
 - 投稿者/管理者による編集・削除
 - IP+UserAgentによる投稿者認証
+- URL owner lookup / batchLookup 対応
 
 ### [7. Yokoso（ようこそ）](./services/yokoso.md)
 
@@ -66,6 +68,7 @@ APIを直接触らずに、すべての機能を試せます。
 - カードモード（長文140文字、アバター・名前付き）
 - デフォルトアバターはピクセルアート招き猫（Lucky Cat、36x36）
 - API経由でメッセージを更新
+- URL owner lookup / batchLookup 対応
 
 ---
 
@@ -94,7 +97,7 @@ Web Componentsのカスタマイズ方法。
 
 ### [10. API仕様](./api.md)
 
-GET専用の統一アクション型API。URLバーから直接操作も可能。
+公開読み取りは GET、オーナー操作は POST body を使う統一アクション型API。
 
 - 全サービス共通のURLパターン
 - 認証とセキュリティ

--- a/docs/user-guide/services/bbs.md
+++ b/docs/user-guide/services/bbs.md
@@ -11,7 +11,8 @@ Message board service with customizable dropdown selections and author-based mes
 Create a new BBS message board.
 
 ```
-GET /api/bbs?action=create&url={URL}&token={TOKEN}&title={TITLE}&maxMessages={MAX_MESSAGES}&messagesPerPage={MESSAGES_PER_PAGE}&webhookUrl={WEBHOOK_URL}&standardSelectLabel={LABEL}&standardSelectOptions={OPTIONS}&incrementalSelectLabel={LABEL}&incrementalSelectOptions={OPTIONS}&emoteSelectLabel={LABEL}&emoteSelectOptions={OPTIONS}
+POST /api/bbs?action=create
+Body: { "url": "{URL}", "token": "{TOKEN}", "title": "{TITLE}", "maxMessages": 100, "messagesPerPage": 20 }
 ```
 
 **Parameters:**
@@ -95,7 +96,8 @@ GET /api/bbs?action=update&id={ID}&messageId={MESSAGE_ID}&message={NEW_MESSAGE}
 #### Message Update - Owner mode (admin)
 
 ```
-GET /api/bbs?action=update&url={URL}&token={TOKEN}&messageId={MESSAGE_ID}&message={NEW_MESSAGE}
+POST /api/bbs?action=update
+Body: { "url": "{URL}", "token": "{TOKEN}", "messageId": "{MESSAGE_ID}", "message": "{NEW_MESSAGE}" }
 ```
 
 **Parameters:**
@@ -123,7 +125,8 @@ GET /api/bbs?action=update&url={URL}&token={TOKEN}&messageId={MESSAGE_ID}&messag
 Update BBS settings without messageId parameter.
 
 ```
-GET /api/bbs?action=update&url={URL}&token={TOKEN}&title={TITLE}&maxMessages={MAX_MESSAGES}&messagesPerPage={MESSAGES_PER_PAGE}&webhookUrl={WEBHOOK_URL}&standardSelectLabel={LABEL}&standardSelectOptions={OPTIONS}&incrementalSelectLabel={LABEL}&incrementalSelectOptions={OPTIONS}&emoteSelectLabel={LABEL}&emoteSelectOptions={OPTIONS}
+POST /api/bbs?action=update
+Body: { "url": "{URL}", "token": "{TOKEN}", "title": "{TITLE}", "maxMessages": 200, "messagesPerPage": 20 }
 ```
 
 **Parameters:**
@@ -169,7 +172,8 @@ GET /api/bbs?action=remove&id={ID}&messageId={MESSAGE_ID}
 **Owner mode (admin):**
 
 ```
-GET /api/bbs?action=remove&url={URL}&token={TOKEN}&messageId={MESSAGE_ID}
+POST /api/bbs?action=remove
+Body: { "url": "{URL}", "token": "{TOKEN}", "messageId": "{MESSAGE_ID}" }
 ```
 
 **Parameters:**
@@ -196,7 +200,8 @@ GET /api/bbs?action=remove&url={URL}&token={TOKEN}&messageId={MESSAGE_ID}
 Clear all messages (owner only).
 
 ```
-GET /api/bbs?action=clear&url={URL}&token={TOKEN}
+POST /api/bbs?action=clear
+Body: { "url": "{URL}", "token": "{TOKEN}" }
 ```
 
 **Parameters:**
@@ -284,10 +289,11 @@ Note: In GitHub README, the image links to a page where users can post messages.
 
 #### Owner Mode (by URL + Token)
 
-Get full settings including webhookUrl.
+Get messages and full settings including webhookUrl. Use `lookup` if you only need to know whether a BBS exists for a URL and what its public ID is.
 
 ```
-GET /api/bbs?action=get&url={URL}&token={TOKEN}&limit={LIMIT}
+POST /api/bbs?action=get
+Body: { "url": "https://yoursite.com", "token": "your-token", "limit": 100 }
 ```
 
 **Parameters:**
@@ -320,12 +326,96 @@ GET /api/bbs?action=get&url={URL}&token={TOKEN}&limit={LIMIT}
 }
 ```
 
+### lookup
+
+Look up the public BBS ID for a URL without loading messages or settings. This is intended for static site build scripts and integrations that only need to know whether the service exists.
+
+`token` must be sent in the POST body, never in the query string.
+
+```
+POST /api/bbs?action=lookup
+Body: { "url": "https://yoursite.com", "token": "your-token" }
+```
+
+**Response (found and authorized):**
+
+```json
+{
+  "success": true,
+  "data": {
+    "url": "https://yoursite.com",
+    "exists": true,
+    "authorized": true,
+    "id": "yoursite-a7b9c3d4",
+    "title": "BBS"
+  }
+}
+```
+
+**Response (not found):**
+
+```json
+{
+  "success": true,
+  "data": {
+    "url": "https://missing.example",
+    "exists": false
+  }
+}
+```
+
+**Response (found but token does not match):**
+
+```json
+{
+  "success": true,
+  "data": {
+    "url": "https://yoursite.com",
+    "exists": true,
+    "authorized": false
+  }
+}
+```
+
+Invalid tokens are reported per item instead of returning request-level `403`, so batch clients can keep ordered results for every requested URL.
+
+### batchLookup
+
+Look up multiple BBS URLs in request order. Missing URLs are included as `{ "exists": false }`; found URLs with a wrong token are included as `{ "exists": true, "authorized": false }`. A single request accepts up to 1000 URLs and internally chunks D1 queries to stay under SQLite bind limits.
+
+```
+POST /api/bbs?action=batchLookup
+Body: { "urls": ["https://a.example", "https://b.example"], "token": "your-token" }
+```
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "data": [
+    {
+      "url": "https://a.example",
+      "exists": true,
+      "authorized": true,
+      "id": "a-a7b9c3d4",
+      "title": "BBS"
+    },
+    {
+      "url": "https://b.example",
+      "exists": false
+    }
+  ]
+}
+```
+
 ### delete
 
 Delete a BBS (owner only).
 
 ```
-GET /api/bbs?action=delete&url={URL}&token={TOKEN}
+POST /api/bbs?action=delete
+Body: { "url": "{URL}", "token": "{TOKEN}" }
 ```
 
 **Parameters:**
@@ -348,9 +438,16 @@ GET /api/bbs?action=delete&url={URL}&token={TOKEN}
 
 ```javascript
 // 1. Create BBS
-const response = await fetch(
-  `/api/bbs?action=create&url=https://mysite.com&token=my-secret&title=My BBS&maxMessages=500`
-);
+const response = await fetch("/api/bbs?action=create", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({
+    url: "https://mysite.com",
+    token: "my-secret",
+    title: "My BBS",
+    maxMessages: 500,
+  }),
+});
 
 const data = await response.json();
 console.log("BBS ID:", data.id);
@@ -375,7 +472,11 @@ await fetch(
 await fetch("/api/bbs?action=remove&id=mysite-a7b9c3d4&messageId=abc123def456");
 
 // Clear all messages (owner only)
-await fetch("/api/bbs?action=clear&url=https://mysite.com&token=my-secret");
+await fetch("/api/bbs?action=clear", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({ url: "https://mysite.com", token: "my-secret" }),
+});
 ```
 
 ## Features

--- a/docs/user-guide/services/counter.md
+++ b/docs/user-guide/services/counter.md
@@ -124,7 +124,8 @@ GET /api/visit?action=get&id={ID}&type={TYPE}&theme={THEME}&format={FORMAT}
 Get full settings including webhookUrl.
 
 ```
-GET /api/visit?action=get&url={URL}&token={TOKEN}
+POST /api/visit?action=get
+Body: { "url": "{URL}", "token": "{TOKEN}" }
 ```
 
 **Parameters:**
@@ -154,7 +155,8 @@ GET /api/visit?action=get&url={URL}&token={TOKEN}
 Update counter value and/or settings (owner only).
 
 ```
-GET /api/visit?action=update&url={URL}&token={TOKEN}&value={VALUE}&webhookUrl={WEBHOOK_URL}
+POST /api/visit?action=update
+Body: { "url": "{URL}", "token": "{TOKEN}", "value": 12345, "webhookUrl": "{WEBHOOK_URL}" }
 ```
 
 **Parameters:**
@@ -185,7 +187,8 @@ Only specify the parameters you want to change.
 Delete a counter (owner only).
 
 ```
-GET /api/visit?action=delete&url={URL}&token={TOKEN}
+POST /api/visit?action=delete
+Body: { "url": "{URL}", "token": "{TOKEN}" }
 ```
 
 **Parameters:**

--- a/docs/user-guide/services/like.md
+++ b/docs/user-guide/services/like.md
@@ -100,7 +100,8 @@ Note: In GitHub README, the image links to a page where users can actually click
 Get full settings including webhookUrl.
 
 ```
-GET /api/like?action=get&url={URL}&token={TOKEN}
+POST /api/like?action=get
+Body: { "url": "{URL}", "token": "{TOKEN}" }
 ```
 
 **Parameters:**
@@ -130,7 +131,8 @@ GET /api/like?action=get&url={URL}&token={TOKEN}
 Update settings (owner only).
 
 ```
-GET /api/like?action=update&url={URL}&token={TOKEN}&webhookUrl={WEBHOOK_URL}
+POST /api/like?action=update
+Body: { "url": "{URL}", "token": "{TOKEN}", "webhookUrl": "{WEBHOOK_URL}" }
 ```
 
 **Parameters:**
@@ -157,7 +159,8 @@ GET /api/like?action=update&url={URL}&token={TOKEN}&webhookUrl={WEBHOOK_URL}
 Delete a like button (owner only).
 
 ```
-GET /api/like?action=delete&url={URL}&token={TOKEN}
+POST /api/like?action=delete
+Body: { "url": "{URL}", "token": "{TOKEN}" }
 ```
 
 **Parameters:**

--- a/docs/user-guide/services/ranking.md
+++ b/docs/user-guide/services/ranking.md
@@ -11,7 +11,8 @@ Score leaderboard system with automatic sorting, score management, and configura
 Create a new ranking leaderboard.
 
 ```
-GET /api/ranking?action=create&url={URL}&token={TOKEN}&title={TITLE}&maxEntries={MAX_ENTRIES}&sortOrder={SORT_ORDER}&webhookUrl={WEBHOOK_URL}
+POST /api/ranking?action=create
+Body: { "url": "{URL}", "token": "{TOKEN}", "title": "{TITLE}", "maxEntries": 100, "sortOrder": "desc" }
 ```
 
 **Parameters:**
@@ -74,7 +75,8 @@ GET /api/ranking?action=submit&id={ID}&name={PLAYER_NAME}&score={SCORE}
 Update ranking settings (owner only).
 
 ```
-GET /api/ranking?action=update&url={URL}&token={TOKEN}&title={TITLE}&maxEntries={MAX_ENTRIES}&sortOrder={SORT_ORDER}&webhookUrl={WEBHOOK_URL}
+POST /api/ranking?action=update
+Body: { "url": "{URL}", "token": "{TOKEN}", "title": "{TITLE}", "maxEntries": 50, "sortOrder": "desc" }
 ```
 
 **Parameters:**
@@ -109,7 +111,8 @@ At least one of title, maxEntries, sortOrder, or webhookUrl is required.
 Remove a specific player's score.
 
 ```
-GET /api/ranking?action=remove&url={URL}&token={TOKEN}&name={PLAYER_NAME}
+POST /api/ranking?action=remove
+Body: { "url": "{URL}", "token": "{TOKEN}", "name": "{PLAYER_NAME}" }
 ```
 
 **Parameters:**
@@ -136,7 +139,8 @@ GET /api/ranking?action=remove&url={URL}&token={TOKEN}&name={PLAYER_NAME}
 Clear all scores from the ranking.
 
 ```
-GET /api/ranking?action=clear&url={URL}&token={TOKEN}
+POST /api/ranking?action=clear
+Body: { "url": "{URL}", "token": "{TOKEN}" }
 ```
 
 **Parameters:**
@@ -204,10 +208,11 @@ GET /api/ranking?action=get&id={ID}&limit={LIMIT}
 
 #### Owner Mode (by URL + Token)
 
-Get full settings including webhookUrl.
+Get leaderboard entries and full settings including webhookUrl. Use `lookup` if you only need to know whether a ranking exists for a URL and what its public ID is.
 
 ```
-GET /api/ranking?action=get&url={URL}&token={TOKEN}&limit={LIMIT}
+POST /api/ranking?action=get
+Body: { "url": "https://yoursite.com", "token": "your-token", "limit": 10 }
 ```
 
 **Parameters:**
@@ -235,12 +240,96 @@ GET /api/ranking?action=get&url={URL}&token={TOKEN}&limit={LIMIT}
 }
 ```
 
+### lookup
+
+Look up the public ranking ID for a URL without loading leaderboard entries or settings. This is intended for static site build scripts and integrations that only need to know whether the service exists.
+
+`token` must be sent in the POST body, never in the query string.
+
+```
+POST /api/ranking?action=lookup
+Body: { "url": "https://mygame.com", "token": "your-token" }
+```
+
+**Response (found and authorized):**
+
+```json
+{
+  "success": true,
+  "data": {
+    "url": "https://mygame.com",
+    "exists": true,
+    "authorized": true,
+    "id": "mygame-a7b9c3d4",
+    "title": "HIGH SCORE"
+  }
+}
+```
+
+**Response (not found):**
+
+```json
+{
+  "success": true,
+  "data": {
+    "url": "https://missing.example",
+    "exists": false
+  }
+}
+```
+
+**Response (found but token does not match):**
+
+```json
+{
+  "success": true,
+  "data": {
+    "url": "https://mygame.com",
+    "exists": true,
+    "authorized": false
+  }
+}
+```
+
+Invalid tokens are reported per item instead of returning request-level `403`, so batch clients can keep ordered results for every requested URL.
+
+### batchLookup
+
+Look up multiple ranking URLs in request order. Missing URLs are included as `{ "exists": false }`; found URLs with a wrong token are included as `{ "exists": true, "authorized": false }`. A single request accepts up to 1000 URLs and internally chunks D1 queries to stay under SQLite bind limits.
+
+```
+POST /api/ranking?action=batchLookup
+Body: { "urls": ["https://a.example", "https://b.example"], "token": "your-token" }
+```
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "data": [
+    {
+      "url": "https://a.example",
+      "exists": true,
+      "authorized": true,
+      "id": "a-a7b9c3d4",
+      "title": "HIGH SCORE"
+    },
+    {
+      "url": "https://b.example",
+      "exists": false
+    }
+  ]
+}
+```
+
 ### delete
 
 Delete a ranking (owner only).
 
 ```
-GET /api/ranking?action=delete&url={URL}&token={TOKEN}
+POST /api/ranking?action=delete
+Body: { "url": "{URL}", "token": "{TOKEN}" }
 ```
 
 **Parameters:**
@@ -263,9 +352,16 @@ GET /api/ranking?action=delete&url={URL}&token={TOKEN}
 
 ```javascript
 // 1. Create ranking for score-based game (high scores win)
-const response = await fetch(
-  "/api/ranking?action=create&url=https://mygame.com&token=game-secret&maxEntries=50&sortOrder=desc"
-);
+const response = await fetch("/api/ranking?action=create", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({
+    url: "https://mygame.com",
+    token: "game-secret",
+    maxEntries: 50,
+    sortOrder: "desc",
+  }),
+});
 const data = await response.json();
 console.log("Ranking ID:", data.id);
 
@@ -283,9 +379,16 @@ console.log("Top players:", leaderboard.entries);
 
 ```javascript
 // 1. Create ranking for time-based game (lower times win)
-const response = await fetch(
-  "/api/ranking?action=create&url=https://racegame.com&token=race-secret&maxEntries=100&sortOrder=asc"
-);
+const response = await fetch("/api/ranking?action=create", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({
+    url: "https://racegame.com",
+    token: "race-secret",
+    maxEntries: 100,
+    sortOrder: "asc",
+  }),
+});
 const data = await response.json();
 console.log("Race Ranking ID:", data.id);
 
@@ -307,15 +410,30 @@ await fetch(
 await fetch("/api/ranking?action=submit&id=mygame-a7b9c3d4&name=Alice&score=1500");
 
 // Remove cheating player
-await fetch("/api/ranking?action=remove&url=https://mygame.com&token=game-secret&name=Cheater");
+await fetch("/api/ranking?action=remove", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({ url: "https://mygame.com", token: "game-secret", name: "Cheater" }),
+});
 
 // Clear all scores (reset season)
-await fetch("/api/ranking?action=clear&url=https://mygame.com&token=game-secret");
+await fetch("/api/ranking?action=clear", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({ url: "https://mygame.com", token: "game-secret" }),
+});
 
 // Update settings
-await fetch(
-  "/api/ranking?action=update&url=https://mygame.com&token=game-secret&maxEntries=50&sortOrder=asc"
-);
+await fetch("/api/ranking?action=update", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({
+    url: "https://mygame.com",
+    token: "game-secret",
+    maxEntries: 50,
+    sortOrder: "asc",
+  }),
+});
 ```
 
 ## Features

--- a/docs/user-guide/services/yokoso.md
+++ b/docs/user-guide/services/yokoso.md
@@ -50,7 +50,8 @@ Longer message up to 140 characters with avatar, name, and date.
 Create a new yokoso.
 
 ```
-GET /api/yokoso?action=create&url={URL}&token={TOKEN}&message={MESSAGE}&mode={MODE}&name={NAME}&avatar={AVATAR_URL}&webhookUrl={WEBHOOK_URL}
+POST /api/yokoso?action=create
+Body: { "url": "{URL}", "token": "{TOKEN}", "message": "{MESSAGE}", "mode": "badge" }
 ```
 
 **Parameters:**
@@ -116,10 +117,11 @@ GET /api/yokoso?action=get&id={ID}&format={FORMAT}
 
 #### Owner Mode (by URL + Token)
 
-Get full settings including webhookUrl.
+Get message data and full settings including webhookUrl. Use `lookup` if you only need to know whether a yokoso exists for a URL and what its public ID is.
 
 ```
-GET /api/yokoso?action=get&url={URL}&token={TOKEN}
+POST /api/yokoso?action=get
+Body: { "url": "https://yoursite.com", "token": "your-token" }
 ```
 
 **Parameters:**
@@ -147,12 +149,96 @@ GET /api/yokoso?action=get&url={URL}&token={TOKEN}
 }
 ```
 
+### lookup
+
+Look up the public yokoso ID for a URL without loading message data or settings. This is intended for static site build scripts and integrations that only need to know whether the service exists.
+
+`token` must be sent in the POST body, never in the query string.
+
+```
+POST /api/yokoso?action=lookup
+Body: { "url": "https://myproject.com", "token": "your-token" }
+```
+
+**Response (found and authorized):**
+
+```json
+{
+  "success": true,
+  "data": {
+    "url": "https://myproject.com",
+    "exists": true,
+    "authorized": true,
+    "id": "myproject-a7b9c3d4",
+    "title": "Yokoso"
+  }
+}
+```
+
+**Response (not found):**
+
+```json
+{
+  "success": true,
+  "data": {
+    "url": "https://missing.example",
+    "exists": false
+  }
+}
+```
+
+**Response (found but token does not match):**
+
+```json
+{
+  "success": true,
+  "data": {
+    "url": "https://myproject.com",
+    "exists": true,
+    "authorized": false
+  }
+}
+```
+
+Invalid tokens are reported per item instead of returning request-level `403`, so batch clients can keep ordered results for every requested URL.
+
+### batchLookup
+
+Look up multiple yokoso URLs in request order. Missing URLs are included as `{ "exists": false }`; found URLs with a wrong token are included as `{ "exists": true, "authorized": false }`. A single request accepts up to 1000 URLs and internally chunks D1 queries to stay under SQLite bind limits.
+
+```
+POST /api/yokoso?action=batchLookup
+Body: { "urls": ["https://a.example", "https://b.example"], "token": "your-token" }
+```
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "data": [
+    {
+      "url": "https://a.example",
+      "exists": true,
+      "authorized": true,
+      "id": "a-a7b9c3d4",
+      "title": "Yokoso"
+    },
+    {
+      "url": "https://b.example",
+      "exists": false
+    }
+  ]
+}
+```
+
 ### update
 
 Update yokoso message and settings (owner only).
 
 ```
-GET /api/yokoso?action=update&url={URL}&token={TOKEN}&message={MESSAGE}&mode={MODE}&name={NAME}&avatar={AVATAR_URL}&webhookUrl={WEBHOOK_URL}
+POST /api/yokoso?action=update
+Body: { "url": "{URL}", "token": "{TOKEN}", "message": "{MESSAGE}", "mode": "badge" }
 ```
 
 **Parameters:**
@@ -184,7 +270,8 @@ GET /api/yokoso?action=update&url={URL}&token={TOKEN}&message={MESSAGE}&mode={MO
 Delete a yokoso (owner only).
 
 ```
-GET /api/yokoso?action=delete&url={URL}&token={TOKEN}
+POST /api/yokoso?action=delete
+Body: { "url": "{URL}", "token": "{TOKEN}" }
 ```
 
 **Parameters:**
@@ -252,9 +339,15 @@ declare module "react" {
 
 ```javascript
 // 1. Create yokoso (badge mode)
-const response = await fetch(
-  "/api/yokoso?action=create&url=https://myproject.com&token=my-secret&message=ようこそ！"
-);
+const response = await fetch("/api/yokoso?action=create", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({
+    url: "https://myproject.com",
+    token: "my-secret",
+    message: "ようこそ！",
+  }),
+});
 const data = await response.json();
 console.log("Yokoso ID:", data.id);
 
@@ -269,27 +362,33 @@ document.body.innerHTML += `
 
 ```javascript
 // Create card mode yokoso with your own avatar
-const response = await fetch(
-  "/api/yokoso?action=create" +
-    "&url=https://myproject.com" +
-    "&token=my-secret" +
-    "&message=v2.0開発中です！新機能としてYokoso機能を追加予定。お楽しみに！" +
-    "&mode=card" +
-    "&name=kako-jun" +
-    "&avatar=https://github.com/kako-jun.png"
-);
+const response = await fetch("/api/yokoso?action=create", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({
+    url: "https://myproject.com",
+    token: "my-secret",
+    message: "v2.0開発中です！新機能としてYokoso機能を追加予定。お楽しみに！",
+    mode: "card",
+    name: "kako-jun",
+    avatar: "https://github.com/kako-jun.png",
+  }),
+});
 ```
 
 ### Update Yokoso Message
 
 ```javascript
 // Update message without editing README
-await fetch(
-  "/api/yokoso?action=update" +
-    "&url=https://myproject.com" +
-    "&token=my-secret" +
-    "&message=v2.0リリースしました！"
-);
+await fetch("/api/yokoso?action=update", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({
+    url: "https://myproject.com",
+    token: "my-secret",
+    message: "v2.0リリースしました！",
+  }),
+});
 // The badge/card in README automatically shows new message
 ```
 


### PR DESCRIPTION
## Summary
- add lightweight lookup and batchLookup for BBS, Ranking, and Yokoso
- keep owner-token actions on POST and batch arrays on POST, matching existing Nostalgic method rules
- derive internal D1 chunk size from bind limits instead of using an unexplained magic number
- update docs and demo UI for lookup flows

## Verification
- env -u NODE_OPTIONS pnpm --filter @nostalgic/api test
- env -u NODE_OPTIONS pnpm --filter @nostalgic/api exec tsc --noEmit
- env -u NODE_OPTIONS pnpm --filter @nostalgic/web build
- env -u NODE_OPTIONS pnpm lint
- env -u NODE_OPTIONS pnpm --filter @nostalgic/api exec wrangler deploy --dry-run