### PR TITLE
fix: BBS埋め込みページの注記からGitHubの言及を削除

### DIFF
--- a/apps/web/src/pages/BBS.tsx
+++ b/apps/web/src/pages/BBS.tsx
@@ -13,11 +13,11 @@ import { bbsEmbedConfig } from "../config/embedConfigs";
 const embedTexts = {
   ja: {
     title: "ここにコメントを書き込んでください！",
-    note: "※GitHubアカウント不要で誰でも書き込めます",
+    note: "※アカウント不要で誰でも書き込めます",
   },
   en: {
     title: "Leave a comment here!",
-    note: "*No GitHub account required - anyone can post",
+    note: "*No account required - anyone can post",
   },
 };
 


### PR DESCRIPTION
## 関連 Issue
closes #13

## 変更内容
- `/bbs?id=...` 埋め込みページの注記を変更
  - ja: ※GitHubアカウント不要で誰でも書き込めます → ※アカウント不要で誰でも書き込めます
  - en: *No GitHub account required - anyone can post → *No account required - anyone can post
- Like ページの同パターンはスコープ外（Issue 参照）

## 検証
- `pnpm --filter @nostalgic/web build` pass