### PR TITLE
fix: usageページのAPI呼び出しをフルURLに一本化（表示URL=fetch URL） 

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -142,10 +142,10 @@ https://api.nostalgic.llll-ll.com/yokoso?action=create&url=https://yoursite.com&
 
 ## 🔧 API アーキテクチャ
 
-すべてのサービスは**GET リクエストのみ**の統一されたアクション型APIパターンに従います:
+すべてのサービスは**GET リクエストのみ**の統一されたアクション型APIパターンに従います。ベースURLは `https://api.nostalgic.llll-ll.com` です:
 
 ```
-/api/{service}?action={action}&url={your-site}&token={your-token}&...params
+/{service}?action={action}&url={your-site}&token={your-token}&...params
 ```
 
 ### 🌐 なぜGETのみ？ 1990年代Web文化への回帰

--- a/README.md
+++ b/README.md
@@ -154,11 +154,11 @@ Visit our interactive demo pages:
 
 ## 🔧 API Architecture
 
-All services follow a unified action-based API pattern. Every action accepts **GET** with query parameters — you can run any of them straight from the browser address bar, like the old web:
+All services follow a unified action-based API pattern. Every action accepts **GET** with query parameters — you can run any of them straight from the browser address bar, like the old web. The base URL is `https://api.nostalgic.llll-ll.com`:
 
 ```
-GET /api/{service}?action=get&id={public-id}
-GET /api/{service}?action={owner-action}&url={your-site}&token={your-token}
+GET /{service}?action=get&id={public-id}
+GET /{service}?action={owner-action}&url={your-site}&token={your-token}
 ```
 
 POST with a JSON body is also supported (body values take precedence over query parameters; `action` is always read from the query string). The batch actions (`batchGet`, `batchCreate`, `batchLookup`) are POST-only because they carry array payloads.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "dompurify": "^3.3.3",
@@ -16,10 +17,12 @@
   },
   "devDependencies": {
     "@types/dompurify": "^3.2.0",
+    "@types/node": "^25.9.1",
     "@types/react": "^18.3.0",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.0",
     "typescript": "^5.7.2",
-    "vite": "^6.0.0"
+    "vite": "^6.0.0",
+    "vitest": "^4.1.8"
   }
 }

--- a/apps/web/src/__tests__/noRelativeApiUrl.test.ts
+++ b/apps/web/src/__tests__/noRelativeApiUrl.test.ts
@@ -1,0 +1,60 @@
+/**
+ * 相対 /api/... 再混入ガード (Issue #17)
+ *
+ * apps/web/src 配下のソースに、相対パスの API 呼び出しリテラル
+ * （`"/api/visit` や `` `/api/ranking `` 等）が再混入していないことを
+ * fs で機械的に検査する。vite proxy 撤去後に相対 /api を書くと本番で 404 になる。
+ */
+
+import { describe, test, expect } from "vitest";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const SRC_DIR = resolve(__dirname, "..");
+
+// 検査対象から除外するファイル名（テスト自身・型宣言）
+const EXCLUDE_FILES = new Set(["noRelativeApiUrl.test.ts", "usageApiUrl.test.ts", "vite-env.d.ts"]);
+
+// 再混入を禁じる相対リテラルのパターン。
+// クォート/バッククォート直後に /api/{service} が来る形を検出する。
+const FORBIDDEN_PATTERNS = [
+  /["'`]\/api\/visit/,
+  /["'`]\/api\/like/,
+  /["'`]\/api\/bbs/,
+  /["'`]\/api\/ranking/,
+  /["'`]\/api\/yokoso/,
+  // service 名を問わない一般形（クォート直後の相対 /api/）も禁止
+  /["'`]\/api\//,
+];
+
+function collectSourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      out.push(...collectSourceFiles(full));
+    } else if (/\.(ts|tsx)$/.test(entry) && !EXCLUDE_FILES.has(entry)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe("再混入ガード: 相対 /api リテラル", () => {
+  const files = collectSourceFiles(SRC_DIR);
+
+  // 走査が空振りしていないことの保証（除外漏れ・パス誤りの早期検出）
+  test("apps/web/src 配下に検査対象の .ts/.tsx ファイルが存在する", () => {
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  // 観点5: いずれのソースにも相対 /api/ リテラルが無い
+  test.each(FORBIDDEN_PATTERNS.map((p) => [p.source, p] as const))(
+    "ソースに相対リテラル %s が含まれない",
+    (_label, pattern) => {
+      const offenders = files.filter((f) => pattern.test(readFileSync(f, "utf8")));
+      expect(offenders).toEqual([]);
+    }
+  );
+});

--- a/apps/web/src/__tests__/usageApiUrl.test.ts
+++ b/apps/web/src/__tests__/usageApiUrl.test.ts
@@ -1,0 +1,193 @@
+/**
+ * usage ページの API URL 構築の回帰テスト (Issue #17)
+ *
+ * usage の各 *Steps の buildApiUrl / buildApiUrlDisplay が
+ * API_BASE 起点のフル URL を生成し、相対 `/api/...` を一切含まないことを守る。
+ * vite proxy 撤去後も usage の URL が壊れていないことを保証する。
+ */
+
+import { describe, test, expect } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { createElement } from "react";
+import { API_BASE, type StepConfig } from "../config/commonSteps";
+import { counterSteps } from "../config/services/counterSteps";
+import { likeSteps } from "../config/services/likeSteps";
+import { rankingSteps } from "../config/services/rankingSteps";
+import { bbsSteps } from "../config/services/bbsSteps";
+import { yokosoSteps } from "../config/services/yokosoSteps";
+
+// 各サービスの steps 配列と、対応するエンドポイント名（API_BASE 直下のパス）
+const SERVICES: { name: string; endpoint: string; steps: StepConfig[] }[] = [
+  { name: "counter", endpoint: "/visit", steps: counterSteps },
+  { name: "like", endpoint: "/like", steps: likeSteps },
+  { name: "ranking", endpoint: "/ranking", steps: rankingSteps },
+  { name: "bbs", endpoint: "/bbs", steps: bbsSteps },
+  { name: "yokoso", endpoint: "/yokoso", steps: yokosoSteps },
+];
+
+// プレースホルダ用のダミー入力（必須/任意の両方を埋めて action 抽出を安定させる）
+const FILLED_VALUES: Record<string, string> = {
+  url: "https://example.com",
+  token: "mytoken123",
+  publicId: "example-com-abc123",
+  format: "json",
+  setValue: "100",
+  webhookUrl: "https://hooks.slack.com/services/x",
+  // ranking submit/update
+  submitName: "player",
+  submitScore: "1000",
+  submitDisplayScore: "1,000pt",
+  updateName: "player",
+  updateScore: "2000",
+  updateDisplayScore: "2,000pt",
+  removeName: "player",
+};
+
+// buildApiUrlDisplay の ReactNode をテキスト化する
+function displayToText(step: StepConfig, values: Record<string, string>): string {
+  const node = step.buildApiUrlDisplay(values);
+  return renderToStaticMarkup(createElement("div", null, node)).replace(/<[^>]+>/g, "");
+}
+
+describe("環境分岐: API_BASE", () => {
+  // 観点6: API_BASE が末尾 /api を持たない絶対 URL であること
+  test("API_BASE は絶対 URL で末尾に /api を持たない", () => {
+    expect(API_BASE).toMatch(/^https?:\/\//);
+    expect(API_BASE.endsWith("/api")).toBe(false);
+    expect(API_BASE).not.toContain("/api");
+  });
+
+  // 観点6: vitest 実行時は DEV=true なので localhost:8787 になる
+  test("DEV 環境（vitest 実行時）では localhost:8787 を指す", () => {
+    expect(API_BASE).toBe("http://localhost:8787");
+  });
+});
+
+describe.each(SERVICES)("正常系/不変条件: $name の buildApiUrl", ({ endpoint, steps }) => {
+  // 観点1: 全 step の buildApiUrl が `${API_BASE}${endpoint}?` で始まる
+  test.each(steps.map((s) => [s.id, s] as const))(
+    "step '%s' は API_BASE+エンドポイント起点のフル URL を返す",
+    (_id, step) => {
+      const url = step.buildApiUrl(FILLED_VALUES);
+      expect(url.startsWith(`${API_BASE}${endpoint}?`)).toBe(true);
+    }
+  );
+
+  // 観点1: 全 step の buildApiUrl に action= が含まれる
+  test.each(steps.map((s) => [s.id, s] as const))(
+    "step '%s' は action クエリを含む",
+    (_id, step) => {
+      const url = step.buildApiUrl(FILLED_VALUES);
+      expect(url).toMatch(/[?&]action=[a-z]+/);
+    }
+  );
+
+  // 観点1: buildApiUrl は相対 /api/ を一切含まない
+  test.each(steps.map((s) => [s.id, s] as const))(
+    "step '%s' の URL は /api/ を含まない",
+    (_id, step) => {
+      const url = step.buildApiUrl(FILLED_VALUES);
+      expect(url).not.toContain("/api/");
+      expect(url).not.toContain("/api?");
+    }
+  );
+});
+
+describe.each(SERVICES)(
+  "表示と fetch の一致: $name の buildApiUrlDisplay",
+  ({ endpoint, steps }) => {
+    // 観点2: 表示テキストが API_BASE+エンドポイント起点で始まる
+    test.each(steps.map((s) => [s.id, s] as const))(
+      "step '%s' の表示は API_BASE+エンドポイントで始まる",
+      (_id, step) => {
+        const text = displayToText(step, FILLED_VALUES);
+        expect(text.startsWith(`${API_BASE}${endpoint}?`)).toBe(true);
+      }
+    );
+
+    // 観点2: 表示テキストが /api/ を含まない
+    test.each(steps.map((s) => [s.id, s] as const))(
+      "step '%s' の表示は /api/ を含まない",
+      (_id, step) => {
+        const text = displayToText(step, FILLED_VALUES);
+        expect(text).not.toContain("/api/");
+        expect(text).not.toContain("/api?");
+      }
+    );
+
+    // 観点2: 表示の action と buildApiUrl の action が一致する
+    test.each(steps.map((s) => [s.id, s] as const))(
+      "step '%s' の表示 action と fetch URL の action が一致する",
+      (_id, step) => {
+        const urlAction = step.buildApiUrl(FILLED_VALUES).match(/[?&]action=([a-z]+)/)?.[1];
+        const textAction = displayToText(step, FILLED_VALUES).match(/[?&]action=([a-z]+)/)?.[1];
+        expect(textAction).toBe(urlAction);
+      }
+    );
+  }
+);
+
+describe("null/空文字/未設定: optional フィールド", () => {
+  const counterCreate = counterSteps.find((s) => s.id === "create")!;
+  const rankingSubmit = rankingSteps.find((s) => s.id === "submit")!;
+
+  // 観点3: counter create の webhookUrl が未設定なら URL に含まれない
+  test("counter create: webhookUrl 未設定なら webhookUrl= は付かない", () => {
+    const url = counterCreate.buildApiUrl({ url: "https://a.com", token: "tok" });
+    expect(url).not.toContain("webhookUrl=");
+  });
+
+  // 観点3: counter create の webhookUrl が設定済みなら encodeURIComponent されて含まれる
+  test("counter create: webhookUrl 設定時は encodeURIComponent されて付く", () => {
+    const webhookUrl = "https://hooks.example.com/a?b=c";
+    const url = counterCreate.buildApiUrl({
+      url: "https://a.com",
+      token: "tok",
+      webhookUrl,
+    });
+    expect(url).toContain(`webhookUrl=${encodeURIComponent(webhookUrl)}`);
+  });
+
+  // 観点3: ranking submit の displayScore が未設定なら URL に含まれない
+  test("ranking submit: displayScore 未設定なら displayScore= は付かない", () => {
+    const url = rankingSubmit.buildApiUrl({
+      publicId: "id",
+      submitName: "p",
+      submitScore: "1",
+    });
+    expect(url).not.toContain("displayScore=");
+  });
+
+  // 観点3: ranking submit の displayScore が設定済みなら encodeURIComponent されて含まれる
+  test("ranking submit: displayScore 設定時は encodeURIComponent されて付く", () => {
+    const displayScore = "1,234 点";
+    const url = rankingSubmit.buildApiUrl({
+      publicId: "id",
+      submitName: "p",
+      submitScore: "1",
+      submitDisplayScore: displayScore,
+    });
+    expect(url).toContain(`displayScore=${encodeURIComponent(displayScore)}`);
+  });
+});
+
+describe("文字種/エンコード: url 値の percent-encode", () => {
+  const counterCreate = counterSteps.find((s) => s.id === "create")!;
+
+  // 観点4: 日本語を含む url が percent-encode される
+  test("日本語を含む url は percent-encode される", () => {
+    const url = "https://例え.テスト/ページ";
+    const built = counterCreate.buildApiUrl({ url, token: "tok" });
+    expect(built).toContain(`url=${encodeURIComponent(url)}`);
+    expect(built).not.toContain(url); // 生の日本語が残っていないこと
+  });
+
+  // 観点4: & や = を含む url が percent-encode され、クエリ構造を壊さない
+  test("& や = を含む url は percent-encode されクエリを壊さない", () => {
+    const url = "https://example.com/?a=1&b=2";
+    const built = counterCreate.buildApiUrl({ url, token: "tok" });
+    expect(built).toContain(`url=${encodeURIComponent(url)}`);
+    // token パラメータが url 値の生の & で割り込まれていないこと
+    expect(built).toContain("&token=tok");
+  });
+});

--- a/apps/web/src/config/commonSteps.ts
+++ b/apps/web/src/config/commonSteps.ts
@@ -1,6 +1,8 @@
 import { ReactNode } from "react";
 
-export const API_BASE = "https://api.nostalgic.llll-ll.com";
+export const API_BASE = import.meta.env.DEV
+  ? "http://localhost:8787"
+  : "https://api.nostalgic.llll-ll.com";
 
 // Field types
 export type FieldType = "text" | "url" | "number" | "select";

--- a/apps/web/src/config/embedConfigs.ts
+++ b/apps/web/src/config/embedConfigs.ts
@@ -1,3 +1,5 @@
+import { API_BASE } from "./commonSteps";
+
 export const counterEmbedConfig = {
   scriptUrl: "https://nostalgic.llll-ll.com/components/visit.js",
   componentName: "nostalgic-counter",
@@ -20,7 +22,7 @@ export const counterEmbedConfig = {
       { name: "DotsF", value: "dots_f" },
     ],
     getUrl: (publicId: string, theme: string) =>
-      `/api/visit?action=get&id=${publicId}&type=total&theme=${theme}&format=image`,
+      `${API_BASE}/visit?action=get&id=${publicId}&type=total&theme=${theme}&format=image`,
   },
   sections: [
     {

--- a/apps/web/src/config/services/bbsSteps.tsx
+++ b/apps/web/src/config/services/bbsSteps.tsx
@@ -1,7 +1,7 @@
 import { GreenParam } from "../../components/ApiUrlDisplay";
 import { API_BASE, COMMON_FIELDS, type StepConfig } from "../commonSteps";
 
-const ENDPOINT = "/api/bbs";
+const ENDPOINT = "/bbs";
 
 // Create step (STEP 1) - with additional fields for BBS
 const createStep: StepConfig = {

--- a/apps/web/src/config/services/counterSteps.tsx
+++ b/apps/web/src/config/services/counterSteps.tsx
@@ -1,7 +1,7 @@
 import { GreenParam } from "../../components/ApiUrlDisplay";
 import { API_BASE, COMMON_FIELDS, type StepConfig } from "../commonSteps";
 
-const ENDPOINT = "/api/visit";
+const ENDPOINT = "/visit";
 
 // Create step (STEP 1)
 const createStep: StepConfig = {

--- a/apps/web/src/config/services/likeSteps.tsx
+++ b/apps/web/src/config/services/likeSteps.tsx
@@ -1,7 +1,7 @@
 import { GreenParam } from "../../components/ApiUrlDisplay";
 import { API_BASE, COMMON_FIELDS, type StepConfig } from "../commonSteps";
 
-const ENDPOINT = "/api/like";
+const ENDPOINT = "/like";
 
 // Like-specific format options (no image theme)
 const likeFormatField = {

--- a/apps/web/src/config/services/rankingSteps.tsx
+++ b/apps/web/src/config/services/rankingSteps.tsx
@@ -1,7 +1,7 @@
 import { GreenParam } from "../../components/ApiUrlDisplay";
 import { API_BASE, COMMON_FIELDS, type StepConfig } from "../commonSteps";
 
-const ENDPOINT = "/api/ranking";
+const ENDPOINT = "/ranking";
 
 // Create step (STEP 1) - with additional fields for ranking
 const createStep: StepConfig = {

--- a/apps/web/src/config/services/yokosoSteps.tsx
+++ b/apps/web/src/config/services/yokosoSteps.tsx
@@ -1,7 +1,7 @@
 import { GreenParam } from "../../components/ApiUrlDisplay";
 import { API_BASE, COMMON_FIELDS, type StepConfig } from "../commonSteps";
 
-const ENDPOINT = "/api/yokoso";
+const ENDPOINT = "/yokoso";
 
 // Yokoso-specific fields
 const modeField = {

--- a/apps/web/src/pages/BBS.tsx
+++ b/apps/web/src/pages/BBS.tsx
@@ -8,6 +8,7 @@ import { highlightPublicId } from "../components/ApiUrlDisplay";
 import { callApi } from "../utils/apiHelpers";
 import { bbsSteps } from "../config/services/bbsSteps";
 import { bbsEmbedConfig } from "../config/embedConfigs";
+import { API_BASE } from "../config/commonSteps";
 
 // 埋め込みページ用の多言語テキスト
 const embedTexts = {
@@ -119,7 +120,7 @@ export default function BBSPage() {
     e.preventDefault();
     if (!url || !token) return;
 
-    let apiUrl = `/api/bbs?action=create&url=${encodeURIComponent(url)}&token=${encodeURIComponent(token)}`;
+    let apiUrl = `${API_BASE}/bbs?action=create&url=${encodeURIComponent(url)}&token=${encodeURIComponent(token)}`;
     if (title) apiUrl += `&title=${encodeURIComponent(title)}`;
     if (maxMessages) apiUrl += `&maxMessages=${maxMessages}`;
     if (messagesPerPage) apiUrl += `&messagesPerPage=${messagesPerPage}`;
@@ -132,7 +133,7 @@ export default function BBSPage() {
     e.preventDefault();
     if (!url || !token) return;
 
-    const apiUrl = `/api/bbs?action=lookup&url=${encodeURIComponent(url)}&token=${encodeURIComponent(token)}`;
+    const apiUrl = `${API_BASE}/bbs?action=lookup&url=${encodeURIComponent(url)}&token=${encodeURIComponent(token)}`;
     await callApi(apiUrl, setLookupResponse, setPublicId);
   };
 
@@ -140,7 +141,7 @@ export default function BBSPage() {
     e.preventDefault();
     if (!publicId || !postMessage) return;
 
-    let apiUrl = `/api/bbs?action=post&id=${encodeURIComponent(publicId)}&message=${encodeURIComponent(postMessage)}`;
+    let apiUrl = `${API_BASE}/bbs?action=post&id=${encodeURIComponent(publicId)}&message=${encodeURIComponent(postMessage)}`;
     if (postAuthor) apiUrl += `&author=${encodeURIComponent(postAuthor)}`;
     if (standardValue) apiUrl += `&standardValue=${encodeURIComponent(standardValue)}`;
     if (incrementalValue) apiUrl += `&incrementalValue=${encodeURIComponent(incrementalValue)}`;
@@ -153,7 +154,7 @@ export default function BBSPage() {
     e.preventDefault();
     if (!publicId) return;
 
-    const apiUrl = `/api/bbs?action=get&id=${encodeURIComponent(publicId)}`;
+    const apiUrl = `${API_BASE}/bbs?action=get&id=${encodeURIComponent(publicId)}`;
     await callApi(apiUrl, setGetResponse);
   };
 
@@ -161,7 +162,7 @@ export default function BBSPage() {
     e.preventDefault();
     if (!url || !token || !messageId || !editMessage) return;
 
-    const apiUrl = `/api/bbs?action=update&url=${encodeURIComponent(url)}&token=${encodeURIComponent(token)}&messageId=${messageId}&message=${encodeURIComponent(editMessage)}`;
+    const apiUrl = `${API_BASE}/bbs?action=update&url=${encodeURIComponent(url)}&token=${encodeURIComponent(token)}&messageId=${messageId}&message=${encodeURIComponent(editMessage)}`;
     await callApi(apiUrl, setUpdateResponse);
   };
 
@@ -169,7 +170,7 @@ export default function BBSPage() {
     e.preventDefault();
     if (!url || !token || !messageId) return;
 
-    const apiUrl = `/api/bbs?action=remove&url=${encodeURIComponent(url)}&token=${encodeURIComponent(token)}&messageId=${messageId}`;
+    const apiUrl = `${API_BASE}/bbs?action=remove&url=${encodeURIComponent(url)}&token=${encodeURIComponent(token)}&messageId=${messageId}`;
     await callApi(apiUrl, setRemoveResponse);
   };
 
@@ -177,7 +178,7 @@ export default function BBSPage() {
     e.preventDefault();
     if (!url || !token) return;
 
-    const apiUrl = `/api/bbs?action=clear&url=${encodeURIComponent(url)}&token=${encodeURIComponent(token)}`;
+    const apiUrl = `${API_BASE}/bbs?action=clear&url=${encodeURIComponent(url)}&token=${encodeURIComponent(token)}`;
     await callApi(apiUrl, setClearResponse);
   };
 
@@ -185,7 +186,7 @@ export default function BBSPage() {
     e.preventDefault();
     if (!url || !token) return;
 
-    const apiUrl = `/api/bbs?action=delete&url=${encodeURIComponent(url)}&token=${encodeURIComponent(token)}`;
+    const apiUrl = `${API_BASE}/bbs?action=delete&url=${encodeURIComponent(url)}&token=${encodeURIComponent(token)}`;
     await callApi(apiUrl, setDeleteResponse);
   };
 
@@ -193,7 +194,7 @@ export default function BBSPage() {
     e.preventDefault();
     if (!url || !token) return;
 
-    let apiUrl = `/api/bbs?action=update&url=${encodeURIComponent(url)}&token=${encodeURIComponent(token)}`;
+    let apiUrl = `${API_BASE}/bbs?action=update&url=${encodeURIComponent(url)}&token=${encodeURIComponent(token)}`;
     if (settingsTitle) apiUrl += `&title=${encodeURIComponent(settingsTitle)}`;
     if (settingsMaxMessages) apiUrl += `&maxMessages=${settingsMaxMessages}`;
     if (settingsMessagesPerPage) apiUrl += `&messagesPerPage=${settingsMessagesPerPage}`;
@@ -215,7 +216,7 @@ export default function BBSPage() {
     e.preventDefault();
     if (!publicId || !messageId || !editMessage) return;
 
-    const apiUrl = `/api/bbs?action=update&id=${encodeURIComponent(publicId)}&messageId=${messageId}&message=${encodeURIComponent(editMessage)}`;
+    const apiUrl = `${API_BASE}/bbs?action=update&id=${encodeURIComponent(publicId)}&messageId=${messageId}&message=${encodeURIComponent(editMessage)}`;
     await callApi(apiUrl, setUpdateResponse);
   };
 
@@ -223,7 +224,7 @@ export default function BBSPage() {
     e.preventDefault();
     if (!publicId || !messageId) return;
 
-    const apiUrl = `/api/bbs?action=remove&id=${encodeURIComponent(publicId)}&messageId=${messageId}`;
+    const apiUrl = `${API_BASE}/bbs?action=remove&id=${encodeURIComponent(publicId)}&messageId=${messageId}`;
     await callApi(apiUrl, setRemoveResponse);
   };
 

--- a/apps/web/src/pages/Counter.tsx
+++ b/apps/web/src/pages/Counter.tsx
@@ -8,6 +8,7 @@ import { highlightPublicId } from "../components/ApiUrlDisplay";
 import { callApi, callApiWithFormat } from "../utils/apiHelpers";
 import { counterSteps } from "../config/services/counterSteps";
 import { counterEmbedConfig } from "../config/embedConfigs";
+import { API_BASE } from "../config/commonSteps";
 
 export default function CounterPage() {
   const location = useLocation();
@@ -50,7 +51,7 @@ export default function CounterPage() {
     e.preventDefault();
     if (!url || !token) return;
 
-    let apiUrl = `/api/visit?action=create&url=${encodeURIComponent(url)}&token=${encodeURIComponent(token)}`;
+    let apiUrl = `${API_BASE}/visit?action=create&url=${encodeURIComponent(url)}&token=${encodeURIComponent(token)}`;
     if (webhookUrl) apiUrl += `&webhookUrl=${encodeURIComponent(webhookUrl)}`;
 
     await callApi(apiUrl, setCreateResponse, setPublicId);
@@ -60,7 +61,7 @@ export default function CounterPage() {
     e.preventDefault();
     if (!publicId) return;
 
-    const apiUrl = `/api/visit?action=get&id=${encodeURIComponent(publicId)}&type=total&format=${format}`;
+    const apiUrl = `${API_BASE}/visit?action=get&id=${encodeURIComponent(publicId)}&type=total&format=${format}`;
     await callApiWithFormat(
       apiUrl,
       format as "json" | "text" | "image",
@@ -73,7 +74,7 @@ export default function CounterPage() {
     e.preventDefault();
     if (!publicId) return;
 
-    const apiUrl = `/api/visit?action=increment&id=${encodeURIComponent(publicId)}`;
+    const apiUrl = `${API_BASE}/visit?action=increment&id=${encodeURIComponent(publicId)}`;
     await callApi(apiUrl, setIncrementResponse);
   };
 
@@ -81,7 +82,7 @@ export default function CounterPage() {
     e.preventDefault();
     if (!publicId) return;
 
-    const apiUrl = `/api/visit?action=get&id=${encodeURIComponent(publicId)}`;
+    const apiUrl = `${API_BASE}/visit?action=get&id=${encodeURIComponent(publicId)}`;
     await callApi(apiUrl, setGetResponse);
   };
 
@@ -89,7 +90,7 @@ export default function CounterPage() {
     e.preventDefault();
     if (!url || !token || !setValue) return;
 
-    const apiUrl = `/api/visit?action=set&url=${encodeURIComponent(url)}&token=${encodeURIComponent(token)}&value=${setValue}`;
+    const apiUrl = `${API_BASE}/visit?action=set&url=${encodeURIComponent(url)}&token=${encodeURIComponent(token)}&value=${setValue}`;
     await callApi(apiUrl, setSetResponse);
   };
 
@@ -97,7 +98,7 @@ export default function CounterPage() {
     e.preventDefault();
     if (!url || !token) return;
 
-    const apiUrl = `/api/visit?action=delete&url=${encodeURIComponent(url)}&token=${encodeURIComponent(token)}`;
+    const apiUrl = `${API_BASE}/visit?action=delete&url=${encodeURIComponent(url)}&token=${encodeURIComponent(token)}`;
     await callApi(apiUrl, setDeleteResponse);
   };
 
@@ -105,7 +106,7 @@ export default function CounterPage() {
     e.preventDefault();
     if (!url || !token) return;
 
-    let apiUrl = `/api/visit?action=update&url=${encodeURIComponent(url)}&token=${encodeURIComponent(token)}`;
+    let apiUrl = `${API_BASE}/visit?action=update&url=${encodeURIComponent(url)}&token=${encodeURIComponent(token)}`;
     if (webhookUrl) apiUrl += `&webhookUrl=${encodeURIComponent(webhookUrl)}`;
 
     await callApi(apiUrl, setUpdateSettingsResponse);

--- a/apps/web/src/pages/Like.tsx
+++ b/apps/web/src/pages/Like.tsx
@@ -8,6 +8,7 @@ import { highlightPublicId } from "../components/ApiUrlDisplay";
 import { callApi, callApiWithFormat } from "../utils/apiHelpers";
 import { likeSteps } from "../config/services/likeSteps";
 import { likeEmbedConfig } from "../config/embedConfigs";
+import { API_BASE } from "../config/commonSteps";
 
 // 埋め込みページ用の多言語テキスト
 const embedTexts = {
@@ -74,7 +75,7 @@ export default function LikePage() {
     e.preventDefault();
     if (!url || !token) return;
 
-    let apiUrl = `/api/like?action=create&url=${encodeURIComponent(url)}&token=${encodeURIComponent(token)}`;
+    let apiUrl = `${API_BASE}/like?action=create&url=${encodeURIComponent(url)}&token=${encodeURIComponent(token)}`;
     if (webhookUrl) apiUrl += `&webhookUrl=${encodeURIComponent(webhookUrl)}`;
 
     await callApi(apiUrl, setCreateResponse, setPublicId);
@@ -84,7 +85,7 @@ export default function LikePage() {
     e.preventDefault();
     if (!publicId) return;
 
-    const apiUrl = `/api/like?action=get&id=${encodeURIComponent(publicId)}&format=${format}`;
+    const apiUrl = `${API_BASE}/like?action=get&id=${encodeURIComponent(publicId)}&format=${format}`;
     await callApiWithFormat(
       apiUrl,
       format as "json" | "text" | "image",
@@ -97,7 +98,7 @@ export default function LikePage() {
     e.preventDefault();
     if (!publicId) return;
 
-    const apiUrl = `/api/like?action=toggle&id=${encodeURIComponent(publicId)}`;
+    const apiUrl = `${API_BASE}/like?action=toggle&id=${encodeURIComponent(publicId)}`;
     await callApi(apiUrl, setToggleResponse);
   };
 
@@ -105,7 +106,7 @@ export default function LikePage() {
     e.preventDefault();
     if (!publicId) return;
 
-    const apiUrl = `/api/like?action=get&id=${encodeURIComponent(publicId)}`;
+    const apiUrl = `${API_BASE}/like?action=get&id=${encodeURIComponent(publicId)}`;
     await callApi(apiUrl, setGetResponse);
   };
 
@@ -113,7 +114,7 @@ export default function LikePage() {
     e.preventDefault();
     if (!url || !token) return;
 
-    const apiUrl = `/api/like?action=delete&url=${encodeURIComponent(url)}&token=${encodeURIComponent(token)}`;
+    const apiUrl = `${API_BASE}/like?action=delete&url=${encodeURIComponent(url)}&token=${encodeURIComponent(token)}`;
     await callApi(apiUrl, setDeleteResponse);
   };
 
@@ -121,7 +122,7 @@ export default function LikePage() {
     e.preventDefault();
     if (!url || !token) return;
 
-    let apiUrl = `/api/like?action=update&url=${encodeURIComponent(url)}&token=${encodeURIComponent(token)}`;
+    let apiUrl = `${API_BASE}/like?action=update&url=${encodeURIComponent(url)}&token=${encodeURIComponent(token)}`;
     if (webhookUrl) apiUrl += `&webhookUrl=${encodeURIComponent(webhookUrl)}`;
 
     await callApi(apiUrl, setUpdateSettingsResponse);
@@ -139,7 +140,7 @@ export default function LikePage() {
     if (ids.length === 0) return;
 
     try {
-      const response = await fetch("/api/like?action=batchGet", {
+      const response = await fetch(`${API_BASE}/like?action=batchGet`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ ids }),
@@ -271,7 +272,7 @@ export default function LikePage() {
               wordBreak: "break-all",
             }}
           >
-            POST /api/like?action=batchGet
+            POST {API_BASE}/like?action=batchGet
             <br />
             Body: {"{"} &quot;ids&quot;: [&quot;id-1&quot;, &quot;id-2&quot;, ...] {"}"}
           </code>

--- a/apps/web/src/pages/Ranking.tsx
+++ b/apps/web/src/pages/Ranking.tsx
@@ -9,6 +9,7 @@ import { callApi } from "../utils/apiHelpers";
 import { sanitizeWebComponent } from "../utils/sanitize";
 import { rankingSteps } from "../config/services/rankingSteps";
 import { rankingEmbedConfig } from "../config/embedConfigs";
+import { API_BASE } from "../config/commonSteps";
 
 export default function RankingPage() {
   const location = useLocation();
@@ -85,7 +86,7 @@ export default function RankingPage() {
     e.preventDefault();
     if (!url || !token) return;
 
-    let apiUrl = `/api/ranking?action=create&url=${encodeURIComponent(url)}&token=${encodeURIComponent(token)}`;
+    let apiUrl = `${API_BASE}/ranking?action=create&url=${encodeURIComponent(url)}&token=${encodeURIComponent(token)}`;
     if (title) apiUrl += `&title=${encodeURIComponent(title)}`;
     if (maxEntries) apiUrl += `&maxEntries=${maxEntries}`;
     if (sortOrder) apiUrl += `&sortOrder=${sortOrder}`;
@@ -98,7 +99,7 @@ export default function RankingPage() {
     e.preventDefault();
     if (!url || !token) return;
 
-    const apiUrl = `/api/ranking?action=lookup&url=${encodeURIComponent(url)}&token=${encodeURIComponent(token)}`;
+    const apiUrl = `${API_BASE}/ranking?action=lookup&url=${encodeURIComponent(url)}&token=${encodeURIComponent(token)}`;
     await callApi(apiUrl, setLookupResponse, setPublicId);
   };
 
@@ -106,7 +107,7 @@ export default function RankingPage() {
     e.preventDefault();
     if (!publicId || !submitName || !submitScore) return;
 
-    let apiUrl = `/api/ranking?action=submit&id=${encodeURIComponent(publicId)}&name=${encodeURIComponent(submitName)}&score=${submitScore}`;
+    let apiUrl = `${API_BASE}/ranking?action=submit&id=${encodeURIComponent(publicId)}&name=${encodeURIComponent(submitName)}&score=${submitScore}`;
     if (submitDisplayScore) apiUrl += `&displayScore=${encodeURIComponent(submitDisplayScore)}`;
 
     await callApi(apiUrl, setSubmitResponse);
@@ -116,7 +117,7 @@ export default function RankingPage() {
     e.preventDefault();
     if (!publicId) return;
 
-    const apiUrl = `/api/ranking?action=get&id=${encodeURIComponent(publicId)}`;
+    const apiUrl = `${API_BASE}/ranking?action=get&id=${encodeURIComponent(publicId)}`;
     await callApi(apiUrl, setGetResponse);
   };
 
@@ -124,7 +125,7 @@ export default function RankingPage() {
     e.preventDefault();
     if (!publicId || !updateName || !updateScore) return;
 
-    let apiUrl = `/api/ranking?action=submit&id=${encodeURIComponent(publicId)}&name=${encodeURIComponent(updateName)}&score=${updateScore}`;
+    let apiUrl = `${API_BASE}/ranking?action=submit&id=${encodeURIComponent(publicId)}&name=${encodeURIComponent(updateName)}&score=${updateScore}`;
     if (updateDisplayScore) apiUrl += `&displayScore=${encodeURIComponent(updateDisplayScore)}`;
 
     await callApi(apiUrl, setUpdateResponse);
@@ -134,7 +135,7 @@ export default function RankingPage() {
     e.preventDefault();
     if (!url || !token || !removeName) return;
 
-    const apiUrl = `/api/ranking?action=remove&url=${encodeURIComponent(url)}&token=${encodeURIComponent(token)}&name=${encodeURIComponent(removeName)}`;
+    const apiUrl = `${API_BASE}/ranking?action=remove&url=${encodeURIComponent(url)}&token=${encodeURIComponent(token)}&name=${encodeURIComponent(removeName)}`;
     await callApi(apiUrl, setRemoveResponse);
   };
 
@@ -142,7 +143,7 @@ export default function RankingPage() {
     e.preventDefault();
     if (!url || !token) return;
 
-    const apiUrl = `/api/ranking?action=clear&url=${encodeURIComponent(url)}&token=${encodeURIComponent(token)}`;
+    const apiUrl = `${API_BASE}/ranking?action=clear&url=${encodeURIComponent(url)}&token=${encodeURIComponent(token)}`;
     await callApi(apiUrl, setClearResponse);
   };
 
@@ -150,7 +151,7 @@ export default function RankingPage() {
     e.preventDefault();
     if (!url || !token) return;
 
-    const apiUrl = `/api/ranking?action=delete&url=${encodeURIComponent(url)}&token=${encodeURIComponent(token)}`;
+    const apiUrl = `${API_BASE}/ranking?action=delete&url=${encodeURIComponent(url)}&token=${encodeURIComponent(token)}`;
     await callApi(apiUrl, setDeleteResponse);
   };
 
@@ -158,7 +159,7 @@ export default function RankingPage() {
     e.preventDefault();
     if (!url || !token) return;
 
-    let apiUrl = `/api/ranking?action=update&url=${encodeURIComponent(url)}&token=${encodeURIComponent(token)}`;
+    let apiUrl = `${API_BASE}/ranking?action=update&url=${encodeURIComponent(url)}&token=${encodeURIComponent(token)}`;
     if (settingsTitle) apiUrl += `&title=${encodeURIComponent(settingsTitle)}`;
     if (settingsMax) apiUrl += `&maxEntries=${settingsMax}`;
     if (settingsSortOrder) apiUrl += `&sortOrder=${settingsSortOrder}`;

--- a/apps/web/src/pages/Yokoso.tsx
+++ b/apps/web/src/pages/Yokoso.tsx
@@ -8,6 +8,7 @@ import { highlightPublicId } from "../components/ApiUrlDisplay";
 import { callApi, callApiWithFormat } from "../utils/apiHelpers";
 import { yokosoSteps } from "../config/services/yokosoSteps";
 import { yokosoEmbedConfig } from "../config/embedConfigs";
+import { API_BASE } from "../config/commonSteps";
 
 export default function YokosoPage() {
   const location = useLocation();
@@ -55,7 +56,7 @@ export default function YokosoPage() {
     e.preventDefault();
     if (!url || !token || !message) return;
 
-    let apiUrl = `/api/yokoso?action=create&url=${encodeURIComponent(url)}&token=${encodeURIComponent(token)}&message=${encodeURIComponent(message)}&mode=${mode}`;
+    let apiUrl = `${API_BASE}/yokoso?action=create&url=${encodeURIComponent(url)}&token=${encodeURIComponent(token)}&message=${encodeURIComponent(message)}&mode=${mode}`;
     if (name) apiUrl += `&name=${encodeURIComponent(name)}`;
     if (avatar) apiUrl += `&avatar=${encodeURIComponent(avatar)}`;
     if (webhookUrl) apiUrl += `&webhookUrl=${encodeURIComponent(webhookUrl)}`;
@@ -67,7 +68,7 @@ export default function YokosoPage() {
     e.preventDefault();
     if (!url || !token) return;
 
-    const apiUrl = `/api/yokoso?action=lookup&url=${encodeURIComponent(url)}&token=${encodeURIComponent(token)}`;
+    const apiUrl = `${API_BASE}/yokoso?action=lookup&url=${encodeURIComponent(url)}&token=${encodeURIComponent(token)}`;
     await callApi(apiUrl, setLookupResponse, setPublicId);
   };
 
@@ -75,7 +76,7 @@ export default function YokosoPage() {
     e.preventDefault();
     if (!publicId) return;
 
-    const apiUrl = `/api/yokoso?action=get&id=${encodeURIComponent(publicId)}&format=${format}`;
+    const apiUrl = `${API_BASE}/yokoso?action=get&id=${encodeURIComponent(publicId)}&format=${format}`;
     await callApiWithFormat(
       apiUrl,
       format as "json" | "text" | "image",
@@ -88,7 +89,7 @@ export default function YokosoPage() {
     e.preventDefault();
     if (!url || !token) return;
 
-    let apiUrl = `/api/yokoso?action=update&url=${encodeURIComponent(url)}&token=${encodeURIComponent(token)}`;
+    let apiUrl = `${API_BASE}/yokoso?action=update&url=${encodeURIComponent(url)}&token=${encodeURIComponent(token)}`;
     if (message) apiUrl += `&message=${encodeURIComponent(message)}`;
     if (mode) apiUrl += `&mode=${mode}`;
     if (name) apiUrl += `&name=${encodeURIComponent(name)}`;
@@ -101,7 +102,7 @@ export default function YokosoPage() {
     e.preventDefault();
     if (!publicId) return;
 
-    const apiUrl = `/api/yokoso?action=get&id=${encodeURIComponent(publicId)}`;
+    const apiUrl = `${API_BASE}/yokoso?action=get&id=${encodeURIComponent(publicId)}`;
     await callApi(apiUrl, setGetResponse);
   };
 
@@ -109,7 +110,7 @@ export default function YokosoPage() {
     e.preventDefault();
     if (!url || !token) return;
 
-    const apiUrl = `/api/yokoso?action=delete&url=${encodeURIComponent(url)}&token=${encodeURIComponent(token)}`;
+    const apiUrl = `${API_BASE}/yokoso?action=delete&url=${encodeURIComponent(url)}&token=${encodeURIComponent(token)}`;
     await callApi(apiUrl, setDeleteResponse);
   };
 

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -21,5 +21,6 @@
     }
   },
   "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -12,13 +12,4 @@ export default defineConfig({
   build: {
     outDir: "dist",
   },
-  server: {
-    proxy: {
-      "/api": {
-        target: "http://localhost:8787",
-        changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/api/, ""),
-      },
-    },
-  },
 });

--- a/docs/development/counter-image-system.md
+++ b/docs/development/counter-image-system.md
@@ -33,7 +33,7 @@
 ## API仕様
 
 ```
-GET /api/visit?action=get&id={ID}&format=image&theme={THEME}
+GET /visit?action=get&id={ID}&format=image&theme={THEME}
 ```
 
 ### format パラメータ

--- a/docs/development/webcomponents-defensive-programming.md
+++ b/docs/development/webcomponents-defensive-programming.md
@@ -181,14 +181,14 @@ if (!response.ok) {
 ```javascript
 // ✅ OK: 未指定属性はURLから除外
 const format = this.safeGetAttribute("format");
-let url = `${baseUrl}/api/service?action=display&id=${id}`;
+let url = `${baseUrl}/${service}?action=display&id=${id}`;
 if (format) {
   url += `&format=${format}`;
 }
 
 // ❌ NG: nullやundefinedをURLに含める
 const format = this.safeGetAttribute("format") || "default";
-const url = `${baseUrl}/api/service?action=display&id=${id}&format=${format}`;
+const url = `${baseUrl}/${service}?action=display&id=${id}&format=${format}`;
 // → format=nullのようなURLになる危険性
 ```
 

--- a/docs/user-guide/api.md
+++ b/docs/user-guide/api.md
@@ -6,17 +6,17 @@ Nostalgic is a comprehensive platform that recreates nostalgic web tools (Counte
 
 ## API Architecture
 
-All services use the same URL pattern with action parameters. Every action accepts **GET** with query parameters — you can run any of them straight from the browser address bar, like the old web:
+All services use the same URL pattern with action parameters. Every action accepts **GET** with query parameters — you can run any of them straight from the browser address bar, like the old web. The base URL is `https://api.nostalgic.llll-ll.com`, so paths below resolve to e.g. `https://api.nostalgic.llll-ll.com/visit?action=get&id=...`:
 
 ```
-GET /api/{service}?action=get&id={public-id}
-GET /api/{service}?action={owner-action}&url={URL}&token={TOKEN}&...
+GET /{service}?action=get&id={public-id}
+GET /{service}?action={owner-action}&url={URL}&token={TOKEN}&...
 ```
 
 POST with a JSON body is also supported (body values take precedence over query parameters). POST bodies must be JSON; HTML form bodies (`application/x-www-form-urlencoded`) are not parsed — use GET forms instead. The batch actions (`batchGet`, `batchCreate`, `batchLookup`) are POST-only because they carry array payloads:
 
 ```
-POST /api/{service}?action=batchLookup
+POST /{service}?action=batchLookup
 Body: { "urls": ["https://a.example", "https://b.example"], "token": "your-token" }
 ```
 

--- a/docs/user-guide/services/bbs.md
+++ b/docs/user-guide/services/bbs.md
@@ -13,7 +13,7 @@ All actions accept GET with query parameters — you can run any of them straigh
 Create a new BBS message board.
 
 ```
-GET /api/bbs?action=create&url={URL}&token={TOKEN}&title={TITLE}&maxMessages=100&messagesPerPage=20
+GET /bbs?action=create&url={URL}&token={TOKEN}&title={TITLE}&maxMessages=100&messagesPerPage=20
 ```
 
 **Parameters:**
@@ -49,7 +49,7 @@ GET /api/bbs?action=create&url={URL}&token={TOKEN}&title={TITLE}&maxMessages=100
 Post a new message to the BBS.
 
 ```
-GET /api/bbs?action=post&id={ID}&author={AUTHOR}&message={MESSAGE}&standardValue={VALUE}&incrementalValue={VALUE}&emoteValue={VALUE}
+GET /bbs?action=post&id={ID}&author={AUTHOR}&message={MESSAGE}&standardValue={VALUE}&incrementalValue={VALUE}&emoteValue={VALUE}
 ```
 
 **Parameters:**
@@ -91,13 +91,13 @@ Update a message or BBS settings.
 #### Message Update - User mode (author)
 
 ```
-GET /api/bbs?action=update&id={ID}&messageId={MESSAGE_ID}&message={NEW_MESSAGE}
+GET /bbs?action=update&id={ID}&messageId={MESSAGE_ID}&message={NEW_MESSAGE}
 ```
 
 #### Message Update - Owner mode (admin)
 
 ```
-GET /api/bbs?action=update&url={URL}&token={TOKEN}&messageId={MESSAGE_ID}&message={NEW_MESSAGE}
+GET /bbs?action=update&url={URL}&token={TOKEN}&messageId={MESSAGE_ID}&message={NEW_MESSAGE}
 ```
 
 **Parameters:**
@@ -125,7 +125,7 @@ GET /api/bbs?action=update&url={URL}&token={TOKEN}&messageId={MESSAGE_ID}&messag
 Update BBS settings without messageId parameter.
 
 ```
-GET /api/bbs?action=update&url={URL}&token={TOKEN}&title={TITLE}&maxMessages=200&messagesPerPage=20
+GET /bbs?action=update&url={URL}&token={TOKEN}&title={TITLE}&maxMessages=200&messagesPerPage=20
 ```
 
 **Parameters:**
@@ -165,13 +165,13 @@ Remove a message.
 **User mode (author):**
 
 ```
-GET /api/bbs?action=remove&id={ID}&messageId={MESSAGE_ID}
+GET /bbs?action=remove&id={ID}&messageId={MESSAGE_ID}
 ```
 
 **Owner mode (admin):**
 
 ```
-GET /api/bbs?action=remove&url={URL}&token={TOKEN}&messageId={MESSAGE_ID}
+GET /bbs?action=remove&url={URL}&token={TOKEN}&messageId={MESSAGE_ID}
 ```
 
 **Parameters:**
@@ -198,7 +198,7 @@ GET /api/bbs?action=remove&url={URL}&token={TOKEN}&messageId={MESSAGE_ID}
 Clear all messages (owner only).
 
 ```
-GET /api/bbs?action=clear&url={URL}&token={TOKEN}
+GET /bbs?action=clear&url={URL}&token={TOKEN}
 ```
 
 **Parameters:**
@@ -226,7 +226,7 @@ Get BBS messages.
 #### Public Mode (by ID)
 
 ```
-GET /api/bbs?action=get&id={ID}&limit={LIMIT}&format={FORMAT}&width={WIDTH}
+GET /bbs?action=get&id={ID}&limit={LIMIT}&format={FORMAT}&width={WIDTH}
 ```
 
 **Parameters:**
@@ -290,7 +290,7 @@ Note: In GitHub README, the image links to a page where users can post messages.
 Get messages and full settings including webhookUrl. Use `lookup` if you only need to know whether a BBS exists for a URL and what its public ID is.
 
 ```
-GET /api/bbs?action=get&url={URL}&token={TOKEN}&limit=100
+GET /bbs?action=get&url={URL}&token={TOKEN}&limit=100
 ```
 
 **Parameters:**
@@ -328,7 +328,7 @@ GET /api/bbs?action=get&url={URL}&token={TOKEN}&limit=100
 Look up the public BBS ID for a URL without loading messages or settings. This is intended for static site build scripts and integrations that only need to know whether the service exists.
 
 ```
-GET /api/bbs?action=lookup&url={URL}&token={TOKEN}
+GET /bbs?action=lookup&url={URL}&token={TOKEN}
 ```
 
 **Response (found and authorized):**
@@ -378,7 +378,7 @@ Invalid tokens are reported per item instead of returning request-level `403`, s
 Look up multiple BBS URLs in request order. Missing URLs are included as `{ "exists": false }`; found URLs with a wrong token are included as `{ "exists": true, "authorized": false }`. A single request accepts up to 1000 URLs and internally chunks D1 queries to stay under SQLite bind limits.
 
 ```
-POST /api/bbs?action=batchLookup
+POST /bbs?action=batchLookup
 Body: { "urls": ["https://a.example", "https://b.example"], "token": "your-token" }
 ```
 
@@ -408,7 +408,7 @@ Body: { "urls": ["https://a.example", "https://b.example"], "token": "your-token
 Delete a BBS (owner only).
 
 ```
-GET /api/bbs?action=delete&url={URL}&token={TOKEN}
+GET /bbs?action=delete&url={URL}&token={TOKEN}
 ```
 
 **Parameters:**
@@ -437,14 +437,14 @@ const params = new URLSearchParams({
   title: "My BBS",
   maxMessages: "500",
 });
-const response = await fetch(`/api/bbs?action=create&${params}`);
+const response = await fetch(`https://api.nostalgic.llll-ll.com/bbs?action=create&${params}`);
 
 const data = await response.json();
 console.log("BBS ID:", data.id);
 
 // 2. Post message with selections
 await fetch(
-  "/api/bbs?action=post&id=" +
+  "https://api.nostalgic.llll-ll.com/bbs?action=post&id=" +
     data.id +
     "&author=Alice&message=Hello everyone!&standardValue=Japan&incrementalValue=General&emoteValue=https://example.com/emote.png"
 );
@@ -455,15 +455,17 @@ await fetch(
 ```javascript
 // Update own message (requires same IP+UserAgent)
 await fetch(
-  "/api/bbs?action=update&id=mysite-a7b9c3d4&messageId=abc123def456&message=Updated message!"
+  "https://api.nostalgic.llll-ll.com/bbs?action=update&id=mysite-a7b9c3d4&messageId=abc123def456&message=Updated message!"
 );
 
 // Remove own message (requires same IP+UserAgent)
-await fetch("/api/bbs?action=remove&id=mysite-a7b9c3d4&messageId=abc123def456");
+await fetch(
+  "https://api.nostalgic.llll-ll.com/bbs?action=remove&id=mysite-a7b9c3d4&messageId=abc123def456"
+);
 
 // Clear all messages (owner only)
 const clearParams = new URLSearchParams({ url: "https://mysite.com", token: "my-secret" });
-await fetch(`/api/bbs?action=clear&${clearParams}`);
+await fetch(`https://api.nostalgic.llll-ll.com/bbs?action=clear&${clearParams}`);
 ```
 
 ## Features

--- a/docs/user-guide/services/counter.md
+++ b/docs/user-guide/services/counter.md
@@ -6,14 +6,14 @@ Traditional visitor counter that tracks visits across multiple time periods with
 
 ## Actions
 
-All actions accept GET with query parameters — you can run any of them straight from the browser address bar, like the old web. POST with a JSON body is also supported (body values take precedence over query parameters). The only exceptions are `batchGet` and `batchCreate`, which require POST because they take array payloads.
+All actions accept GET with query parameters — you can run any of them straight from the browser address bar, like the old web. POST with a JSON body is also supported (body values take precedence over query parameters). The only exceptions are `batchGet` and `batchCreate`, which require POST because they take array payloads. The base URL is `https://api.nostalgic.llll-ll.com`, so the paths below resolve to e.g. `https://api.nostalgic.llll-ll.com/visit?action=create&...`.
 
 ### create
 
 Create a new counter.
 
 ```
-GET /api/visit?action=create&url={URL}&token={TOKEN}&webhookUrl={WEBHOOK_URL}
+GET /visit?action=create&url={URL}&token={TOKEN}&webhookUrl={WEBHOOK_URL}
 ```
 
 **Parameters:**
@@ -38,7 +38,7 @@ GET /api/visit?action=create&url={URL}&token={TOKEN}&webhookUrl={WEBHOOK_URL}
 Count up the counter (automatic duplicate prevention).
 
 ```
-GET /api/visit?action=increment&id={ID}&format={FORMAT}&theme={THEME}&type={TYPE}
+GET /visit?action=increment&id={ID}&format={FORMAT}&theme={THEME}&type={TYPE}
 ```
 
 **Parameters:**
@@ -82,7 +82,7 @@ Get counter data or image.
 #### Public Mode (by ID)
 
 ```
-GET /api/visit?action=get&id={ID}&type={TYPE}&theme={THEME}&format={FORMAT}
+GET /visit?action=get&id={ID}&type={TYPE}&theme={THEME}&format={FORMAT}
 ```
 
 **Parameters:**
@@ -126,7 +126,7 @@ GET /api/visit?action=get&id={ID}&type={TYPE}&theme={THEME}&format={FORMAT}
 Get full settings including webhookUrl.
 
 ```
-GET /api/visit?action=get&url={URL}&token={TOKEN}
+GET /visit?action=get&url={URL}&token={TOKEN}
 ```
 
 **Parameters:**
@@ -156,7 +156,7 @@ GET /api/visit?action=get&url={URL}&token={TOKEN}
 Update counter value and/or settings (owner only).
 
 ```
-GET /api/visit?action=update&url={URL}&token={TOKEN}&value=12345&webhookUrl={WEBHOOK_URL}
+GET /visit?action=update&url={URL}&token={TOKEN}&value=12345&webhookUrl={WEBHOOK_URL}
 ```
 
 **Parameters:**
@@ -187,7 +187,7 @@ Only specify the parameters you want to change.
 Delete a counter (owner only).
 
 ```
-GET /api/visit?action=delete&url={URL}&token={TOKEN}
+GET /visit?action=delete&url={URL}&token={TOKEN}
 ```
 
 **Parameters:**
@@ -209,7 +209,7 @@ GET /api/visit?action=delete&url={URL}&token={TOKEN}
 Sum counter values by ID prefix. Useful for aggregating all counters under a common prefix (e.g., all pages of a site).
 
 ```
-GET /api/visit?action=sumByPrefix&prefix={PREFIX}
+GET /visit?action=sumByPrefix&prefix={PREFIX}
 ```
 
 **Parameters:**
@@ -229,7 +229,9 @@ GET /api/visit?action=sumByPrefix&prefix={PREFIX}
 
 ```javascript
 // Sum all counters for osaka-kenpo (e.g., osaka-kenpo-art1, osaka-kenpo-art2, ...)
-const response = await fetch("/api/visit?action=sumByPrefix&prefix=osaka-kenpo");
+const response = await fetch(
+  "https://api.nostalgic.llll-ll.com/visit?action=sumByPrefix&prefix=osaka-kenpo"
+);
 const { total } = await response.json();
 console.log("Total views:", total);
 ```
@@ -241,7 +243,7 @@ console.log("Total views:", total);
 Get counter values for multiple IDs in a single request.
 
 ```
-POST /api/visit?action=batchGet
+POST /visit?action=batchGet
 Content-Type: application/json
 
 {
@@ -278,7 +280,7 @@ Content-Type: application/json
 Create multiple counters in a single request. Existing IDs/URLs are skipped.
 
 ```
-POST /api/visit?action=batchCreate
+POST /visit?action=batchCreate
 Content-Type: application/json
 
 {
@@ -379,7 +381,9 @@ This prevents TypeScript build errors when using Web Components in React/Next.js
 
 ```javascript
 // 1. Create counter
-const response = await fetch("/api/visit?action=create&url=https://myblog.com&token=my-secret");
+const response = await fetch(
+  "https://api.nostalgic.llll-ll.com/visit?action=create&url=https://myblog.com&token=my-secret"
+);
 const data = await response.json();
 console.log("Counter ID:", data.id);
 
@@ -424,12 +428,14 @@ document.body.innerHTML += `
 
 ```javascript
 // Count manually (no automatic counting)
-const count = await fetch("/api/visit?action=increment&id=blog-a7b9c3d4");
+const count = await fetch(
+  "https://api.nostalgic.llll-ll.com/visit?action=increment&id=blog-a7b9c3d4"
+);
 const data = await count.json();
 
 // Get as image
 document.querySelector("#counter").src =
-  `/api/visit?action=get&id=blog-a7b9c3d4&type=total&theme=light`;
+  `https://api.nostalgic.llll-ll.com/visit?action=get&id=blog-a7b9c3d4&type=total&theme=light`;
 ```
 
 ## Security Notes

--- a/docs/user-guide/services/like.md
+++ b/docs/user-guide/services/like.md
@@ -13,7 +13,7 @@ All actions accept GET with query parameters — you can run any of them straigh
 Create a new like button.
 
 ```
-GET /api/like?action=create&url={URL}&token={TOKEN}&webhookUrl={WEBHOOK_URL}
+GET /like?action=create&url={URL}&token={TOKEN}&webhookUrl={WEBHOOK_URL}
 ```
 
 **Parameters:**
@@ -37,7 +37,7 @@ GET /api/like?action=create&url={URL}&token={TOKEN}&webhookUrl={WEBHOOK_URL}
 Toggle like/unlike state for current user.
 
 ```
-GET /api/like?action=toggle&id={ID}
+GET /like?action=toggle&id={ID}
 ```
 
 **Parameters:**
@@ -64,7 +64,7 @@ Get current like data.
 #### Public Mode (by ID)
 
 ```
-GET /api/like?action=get&id={ID}&format={FORMAT}
+GET /like?action=get&id={ID}&format={FORMAT}
 ```
 
 **Parameters:**
@@ -102,7 +102,7 @@ Note: In GitHub README, the image links to a page where users can actually click
 Get full settings including webhookUrl.
 
 ```
-GET /api/like?action=get&url={URL}&token={TOKEN}
+GET /like?action=get&url={URL}&token={TOKEN}
 ```
 
 **Parameters:**
@@ -132,7 +132,7 @@ GET /api/like?action=get&url={URL}&token={TOKEN}
 Update settings (owner only).
 
 ```
-GET /api/like?action=update&url={URL}&token={TOKEN}&webhookUrl={WEBHOOK_URL}
+GET /like?action=update&url={URL}&token={TOKEN}&webhookUrl={WEBHOOK_URL}
 ```
 
 **Parameters:**
@@ -159,7 +159,7 @@ GET /api/like?action=update&url={URL}&token={TOKEN}&webhookUrl={WEBHOOK_URL}
 Delete a like button (owner only).
 
 ```
-GET /api/like?action=delete&url={URL}&token={TOKEN}
+GET /like?action=delete&url={URL}&token={TOKEN}
 ```
 
 **Parameters:**
@@ -183,7 +183,7 @@ GET /api/like?action=delete&url={URL}&token={TOKEN}
 Get like counts for multiple IDs in a single request. Useful for displaying like counts on list pages without making individual API calls for each item.
 
 ```
-POST /api/like?action=batchGet
+POST /like?action=batchGet
 Content-Type: application/json
 
 {
@@ -218,7 +218,7 @@ Content-Type: application/json
 
 ```javascript
 // Fetch like counts for 100 articles in one request
-const response = await fetch("/api/like?action=batchGet", {
+const response = await fetch("https://api.nostalgic.llll-ll.com/like?action=batchGet", {
   method: "POST",
   headers: { "Content-Type": "application/json" },
   body: JSON.stringify({
@@ -290,7 +290,9 @@ This prevents TypeScript build errors when using Web Components in React/Next.js
 
 ```javascript
 // 1. Create like button
-const response = await fetch("/api/like?action=create&url=https://myblog.com&token=my-secret");
+const response = await fetch(
+  "https://api.nostalgic.llll-ll.com/like?action=create&url=https://myblog.com&token=my-secret"
+);
 const data = await response.json();
 console.log("Like Button ID:", data.id);
 
@@ -326,12 +328,14 @@ document.body.innerHTML += `
 
 ```javascript
 // Toggle like manually
-const response = await fetch("/api/like?action=toggle&id=myblog-a7b9c3d4");
+const response = await fetch(
+  "https://api.nostalgic.llll-ll.com/like?action=toggle&id=myblog-a7b9c3d4"
+);
 const data = await response.json();
 console.log("User liked:", data.userLiked, "Total:", data.total);
 
 // Get current state
-const current = await fetch("/api/like?action=get&id=myblog-a7b9c3d4");
+const current = await fetch("https://api.nostalgic.llll-ll.com/like?action=get&id=myblog-a7b9c3d4");
 const state = await current.json();
 console.log("Current likes:", state.total);
 ```

--- a/docs/user-guide/services/ranking.md
+++ b/docs/user-guide/services/ranking.md
@@ -13,7 +13,7 @@ All actions accept GET with query parameters — you can run any of them straigh
 Create a new ranking leaderboard.
 
 ```
-GET /api/ranking?action=create&url={URL}&token={TOKEN}&title={TITLE}&maxEntries=100&sortOrder=desc
+GET /ranking?action=create&url={URL}&token={TOKEN}&title={TITLE}&maxEntries=100&sortOrder=desc
 ```
 
 **Parameters:**
@@ -42,7 +42,7 @@ GET /api/ranking?action=create&url={URL}&token={TOKEN}&title={TITLE}&maxEntries=
 Submit a new score to the ranking (public access).
 
 ```
-GET /api/ranking?action=submit&id={ID}&name={PLAYER_NAME}&score={SCORE}
+GET /ranking?action=submit&id={ID}&name={PLAYER_NAME}&score={SCORE}
 ```
 
 **Parameters:**
@@ -76,7 +76,7 @@ GET /api/ranking?action=submit&id={ID}&name={PLAYER_NAME}&score={SCORE}
 Update ranking settings (owner only).
 
 ```
-GET /api/ranking?action=update&url={URL}&token={TOKEN}&title={TITLE}&maxEntries=50&sortOrder=desc
+GET /ranking?action=update&url={URL}&token={TOKEN}&title={TITLE}&maxEntries=50&sortOrder=desc
 ```
 
 **Parameters:**
@@ -111,7 +111,7 @@ At least one of title, maxEntries, sortOrder, or webhookUrl is required.
 Remove a specific player's score.
 
 ```
-GET /api/ranking?action=remove&url={URL}&token={TOKEN}&name={PLAYER_NAME}
+GET /ranking?action=remove&url={URL}&token={TOKEN}&name={PLAYER_NAME}
 ```
 
 **Parameters:**
@@ -138,7 +138,7 @@ GET /api/ranking?action=remove&url={URL}&token={TOKEN}&name={PLAYER_NAME}
 Clear all scores from the ranking.
 
 ```
-GET /api/ranking?action=clear&url={URL}&token={TOKEN}
+GET /ranking?action=clear&url={URL}&token={TOKEN}
 ```
 
 **Parameters:**
@@ -166,7 +166,7 @@ Get ranking data.
 #### Public Mode (by ID)
 
 ```
-GET /api/ranking?action=get&id={ID}&limit={LIMIT}
+GET /ranking?action=get&id={ID}&limit={LIMIT}
 ```
 
 **Parameters:**
@@ -209,7 +209,7 @@ GET /api/ranking?action=get&id={ID}&limit={LIMIT}
 Get leaderboard entries and full settings including webhookUrl. Use `lookup` if you only need to know whether a ranking exists for a URL and what its public ID is.
 
 ```
-GET /api/ranking?action=get&url={URL}&token={TOKEN}&limit=10
+GET /ranking?action=get&url={URL}&token={TOKEN}&limit=10
 ```
 
 **Parameters:**
@@ -242,7 +242,7 @@ GET /api/ranking?action=get&url={URL}&token={TOKEN}&limit=10
 Look up the public ranking ID for a URL without loading leaderboard entries or settings. This is intended for static site build scripts and integrations that only need to know whether the service exists.
 
 ```
-GET /api/ranking?action=lookup&url={URL}&token={TOKEN}
+GET /ranking?action=lookup&url={URL}&token={TOKEN}
 ```
 
 **Response (found and authorized):**
@@ -292,7 +292,7 @@ Invalid tokens are reported per item instead of returning request-level `403`, s
 Look up multiple ranking URLs in request order. Missing URLs are included as `{ "exists": false }`; found URLs with a wrong token are included as `{ "exists": true, "authorized": false }`. A single request accepts up to 1000 URLs and internally chunks D1 queries to stay under SQLite bind limits.
 
 ```
-POST /api/ranking?action=batchLookup
+POST /ranking?action=batchLookup
 Body: { "urls": ["https://a.example", "https://b.example"], "token": "your-token" }
 ```
 
@@ -322,7 +322,7 @@ Body: { "urls": ["https://a.example", "https://b.example"], "token": "your-token
 Delete a ranking (owner only).
 
 ```
-GET /api/ranking?action=delete&url={URL}&token={TOKEN}
+GET /ranking?action=delete&url={URL}&token={TOKEN}
 ```
 
 **Parameters:**
@@ -351,16 +351,22 @@ const params = new URLSearchParams({
   maxEntries: "50",
   sortOrder: "desc",
 });
-const response = await fetch(`/api/ranking?action=create&${params}`);
+const response = await fetch(`https://api.nostalgic.llll-ll.com/ranking?action=create&${params}`);
 const data = await response.json();
 console.log("Ranking ID:", data.id);
 
 // 2. Submit scores (using public ID)
-await fetch("/api/ranking?action=submit&id=" + data.id + "&name=Alice&score=1000");
-await fetch("/api/ranking?action=submit&id=" + data.id + "&name=Bob&score=1200");
+await fetch(
+  "https://api.nostalgic.llll-ll.com/ranking?action=submit&id=" + data.id + "&name=Alice&score=1000"
+);
+await fetch(
+  "https://api.nostalgic.llll-ll.com/ranking?action=submit&id=" + data.id + "&name=Bob&score=1200"
+);
 
 // 3. Get leaderboard
-const ranking = await fetch("/api/ranking?action=get&id=mygame-a7b9c3d4&limit=10");
+const ranking = await fetch(
+  "https://api.nostalgic.llll-ll.com/ranking?action=get&id=mygame-a7b9c3d4&limit=10"
+);
 const leaderboard = await ranking.json();
 console.log("Top players:", leaderboard.entries);
 ```
@@ -375,16 +381,20 @@ const params = new URLSearchParams({
   maxEntries: "100",
   sortOrder: "asc",
 });
-const response = await fetch(`/api/ranking?action=create&${params}`);
+const response = await fetch(`https://api.nostalgic.llll-ll.com/ranking?action=create&${params}`);
 const data = await response.json();
 console.log("Race Ranking ID:", data.id);
 
 // 2. Submit times (lower is better)
 await fetch(
-  "/api/ranking?action=submit&id=" + data.id + "&name=Speedster&score=1750&displayScore=17.50s"
+  "https://api.nostalgic.llll-ll.com/ranking?action=submit&id=" +
+    data.id +
+    "&name=Speedster&score=1750&displayScore=17.50s"
 );
 await fetch(
-  "/api/ranking?action=submit&id=" + data.id + "&name=Racer&score=1820&displayScore=18.20s"
+  "https://api.nostalgic.llll-ll.com/ranking?action=submit&id=" +
+    data.id +
+    "&name=Racer&score=1820&displayScore=18.20s"
 );
 
 // Better time (17.50s) will rank higher than worse time (18.20s)
@@ -394,7 +404,9 @@ await fetch(
 
 ```javascript
 // Update player score (submit handles UPSERT - inserts new or updates existing)
-await fetch("/api/ranking?action=submit&id=mygame-a7b9c3d4&name=Alice&score=1500");
+await fetch(
+  "https://api.nostalgic.llll-ll.com/ranking?action=submit&id=mygame-a7b9c3d4&name=Alice&score=1500"
+);
 
 // Remove cheating player
 const removeParams = new URLSearchParams({
@@ -402,11 +414,11 @@ const removeParams = new URLSearchParams({
   token: "game-secret",
   name: "Cheater",
 });
-await fetch(`/api/ranking?action=remove&${removeParams}`);
+await fetch(`https://api.nostalgic.llll-ll.com/ranking?action=remove&${removeParams}`);
 
 // Clear all scores (reset season)
 const clearParams = new URLSearchParams({ url: "https://mygame.com", token: "game-secret" });
-await fetch(`/api/ranking?action=clear&${clearParams}`);
+await fetch(`https://api.nostalgic.llll-ll.com/ranking?action=clear&${clearParams}`);
 
 // Update settings
 const updateParams = new URLSearchParams({
@@ -415,7 +427,7 @@ const updateParams = new URLSearchParams({
   maxEntries: "50",
   sortOrder: "asc",
 });
-await fetch(`/api/ranking?action=update&${updateParams}`);
+await fetch(`https://api.nostalgic.llll-ll.com/ranking?action=update&${updateParams}`);
 ```
 
 ## Features

--- a/docs/user-guide/services/yokoso.md
+++ b/docs/user-guide/services/yokoso.md
@@ -52,7 +52,7 @@ All actions accept GET with query parameters — you can run any of them straigh
 Create a new yokoso.
 
 ```
-GET /api/yokoso?action=create&url={URL}&token={TOKEN}&message={MESSAGE}&mode=badge
+GET /yokoso?action=create&url={URL}&token={TOKEN}&message={MESSAGE}&mode=badge
 ```
 
 **Parameters:**
@@ -82,7 +82,7 @@ Get current yokoso data.
 #### Public Mode (by ID)
 
 ```
-GET /api/yokoso?action=get&id={ID}&format={FORMAT}
+GET /yokoso?action=get&id={ID}&format={FORMAT}
 ```
 
 **Parameters:**
@@ -121,7 +121,7 @@ GET /api/yokoso?action=get&id={ID}&format={FORMAT}
 Get message data and full settings including webhookUrl. Use `lookup` if you only need to know whether a yokoso exists for a URL and what its public ID is.
 
 ```
-GET /api/yokoso?action=get&url={URL}&token={TOKEN}
+GET /yokoso?action=get&url={URL}&token={TOKEN}
 ```
 
 **Parameters:**
@@ -154,7 +154,7 @@ GET /api/yokoso?action=get&url={URL}&token={TOKEN}
 Look up the public yokoso ID for a URL without loading message data or settings. This is intended for static site build scripts and integrations that only need to know whether the service exists.
 
 ```
-GET /api/yokoso?action=lookup&url={URL}&token={TOKEN}
+GET /yokoso?action=lookup&url={URL}&token={TOKEN}
 ```
 
 **Response (found and authorized):**
@@ -204,7 +204,7 @@ Invalid tokens are reported per item instead of returning request-level `403`, s
 Look up multiple yokoso URLs in request order. Missing URLs are included as `{ "exists": false }`; found URLs with a wrong token are included as `{ "exists": true, "authorized": false }`. A single request accepts up to 1000 URLs and internally chunks D1 queries to stay under SQLite bind limits.
 
 ```
-POST /api/yokoso?action=batchLookup
+POST /yokoso?action=batchLookup
 Body: { "urls": ["https://a.example", "https://b.example"], "token": "your-token" }
 ```
 
@@ -234,7 +234,7 @@ Body: { "urls": ["https://a.example", "https://b.example"], "token": "your-token
 Update yokoso message and settings (owner only).
 
 ```
-GET /api/yokoso?action=update&url={URL}&token={TOKEN}&message={MESSAGE}&mode=badge
+GET /yokoso?action=update&url={URL}&token={TOKEN}&message={MESSAGE}&mode=badge
 ```
 
 **Parameters:**
@@ -266,7 +266,7 @@ GET /api/yokoso?action=update&url={URL}&token={TOKEN}&message={MESSAGE}&mode=bad
 Delete a yokoso (owner only).
 
 ```
-GET /api/yokoso?action=delete&url={URL}&token={TOKEN}
+GET /yokoso?action=delete&url={URL}&token={TOKEN}
 ```
 
 **Parameters:**
@@ -339,7 +339,7 @@ const params = new URLSearchParams({
   token: "my-secret",
   message: "ようこそ！",
 });
-const response = await fetch(`/api/yokoso?action=create&${params}`);
+const response = await fetch(`https://api.nostalgic.llll-ll.com/yokoso?action=create&${params}`);
 const data = await response.json();
 console.log("Yokoso ID:", data.id);
 
@@ -362,7 +362,7 @@ const params = new URLSearchParams({
   name: "kako-jun",
   avatar: "https://github.com/kako-jun.png",
 });
-const response = await fetch(`/api/yokoso?action=create&${params}`);
+const response = await fetch(`https://api.nostalgic.llll-ll.com/yokoso?action=create&${params}`);
 ```
 
 ### Update Yokoso Message
@@ -374,7 +374,7 @@ const params = new URLSearchParams({
   token: "my-secret",
   message: "v2.0リリースしました！",
 });
-await fetch(`/api/yokoso?action=update&${params}`);
+await fetch(`https://api.nostalgic.llll-ll.com/yokoso?action=update&${params}`);
 // The badge/card in README automatically shows new message
 ```
 

--- a/docs/user-guide/webhook.md
+++ b/docs/user-guide/webhook.md
@@ -13,19 +13,19 @@ Nostalgicの全サービスはWebHook通知に対応しています。Discord、
 ### サービス作成時
 
 ```
-/api/visit?action=create&url=https://your-site.com&token=yourtoken&webhookUrl=https://discord.com/api/webhooks/xxx
+https://api.nostalgic.llll-ll.com/visit?action=create&url=https://your-site.com&token=yourtoken&webhookUrl=https://discord.com/api/webhooks/xxx
 ```
 
 ### 後から設定/変更
 
 ```
-/api/visit?action=update&url=https://your-site.com&token=yourtoken&webhookUrl=https://hooks.slack.com/xxx
+https://api.nostalgic.llll-ll.com/visit?action=update&url=https://your-site.com&token=yourtoken&webhookUrl=https://hooks.slack.com/xxx
 ```
 
 ### 解除
 
 ```
-/api/visit?action=update&url=https://your-site.com&token=yourtoken&webhookUrl=
+https://api.nostalgic.llll-ll.com/visit?action=update&url=https://your-site.com&token=yourtoken&webhookUrl=
 ```
 
 ## イベント一覧

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,6 +73,9 @@ importers:
       '@types/dompurify':
         specifier: ^3.2.0
         version: 3.2.0
+      '@types/node':
+        specifier: ^25.9.1
+        version: 25.9.1
       '@types/react':
         specifier: ^18.3.0
         version: 18.3.27
@@ -81,13 +84,16 @@ importers:
         version: 18.3.7(@types/react@18.3.27)
       '@vitejs/plugin-react':
         specifier: ^4.3.0
-        version: 4.7.0(vite@6.4.1(yaml@2.8.2))
+        version: 4.7.0(vite@6.4.1(@types/node@25.9.1)(yaml@2.8.2))
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
       vite:
         specifier: ^6.0.0
-        version: 6.4.1(yaml@2.8.2)
+        version: 6.4.1(@types/node@25.9.1)(yaml@2.8.2)
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@25.9.1)(vite@6.4.1(@types/node@25.9.1)(yaml@2.8.2))
 
 packages:
 
@@ -613,67 +619,79 @@ packages:
     resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.0.5':
     resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.0.4':
     resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.0.4':
     resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
     resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.0.4':
     resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.33.5':
     resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.33.5':
     resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.33.5':
     resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.33.5':
     resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.33.5':
     resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.33.5':
     resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.33.5':
     resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
@@ -757,56 +775,67 @@ packages:
     resolution: {integrity: sha512-k9oD15soC/Ln6d2Wv/JOFPzZXIAIFLp6B+i14KhxAfnq76ajt0EhYc5YPeX6W1xJkAdItcVT+JhKl1QZh44/qw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.53.3':
     resolution: {integrity: sha512-vTNlKq+N6CK/8UktsrFuc+/7NlEYVxgaEgRXVUVK258Z5ymho29skzW1sutgYjqNnquGwVUObAaxae8rZ6YMhg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.53.3':
     resolution: {integrity: sha512-RGrFLWgMhSxRs/EWJMIFM1O5Mzuz3Xy3/mnxJp/5cVhZ2XoCAxJnmNsEyeMJtpK+wu0FJFWz+QF4mjCA7AUQ3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.53.3':
     resolution: {integrity: sha512-kASyvfBEWYPEwe0Qv4nfu6pNkITLTb32p4yTgzFCocHnJLAHs+9LjUu9ONIhvfT/5lv4YS5muBHyuV84epBo/A==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.53.3':
     resolution: {integrity: sha512-JiuKcp2teLJwQ7vkJ95EwESWkNRFJD7TQgYmCnrPtlu50b4XvT5MOmurWNrCj3IFdyjBQ5p9vnrX4JM6I8OE7g==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.53.3':
     resolution: {integrity: sha512-EoGSa8nd6d3T7zLuqdojxC20oBfNT8nexBbB/rkxgKj5T5vhpAQKKnD+h3UkoMuTyXkP5jTjK/ccNRmQrPNDuw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.53.3':
     resolution: {integrity: sha512-4s+Wped2IHXHPnAEbIB0YWBv7SDohqxobiiPA1FIWZpX+w9o2i4LezzH/NkFUl8LRci/8udci6cLq+jJQlh+0g==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.53.3':
     resolution: {integrity: sha512-68k2g7+0vs2u9CxDt5ktXTngsxOQkSEV/xBbwlqYcUrAVh6P9EgMZvFsnHy4SEiUl46Xf0IObWVbMvPrr2gw8A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.53.3':
     resolution: {integrity: sha512-VYsFMpULAz87ZW6BVYw3I6sWesGpsP9OPcyKe8ofdg9LHxSbRMd7zrVrr5xi/3kMZtpWL/wC+UIJWJYVX5uTKg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.53.3':
     resolution: {integrity: sha512-3EhFi1FU6YL8HTUJZ51imGJWEX//ajQPfqWLI3BQq4TlvHy4X0MOr5q3D2Zof/ka0d5FNdPwZXm3Yyib/UEd+w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.53.3':
     resolution: {integrity: sha512-eoROhjcc6HbZCJr+tvVT8X4fW3/5g/WkGvvmwz/88sDtSJzO7r/blvoBDgISDiCjDRZmHpwud7h+6Q9JxFwq1Q==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.53.3':
     resolution: {integrity: sha512-OueLAWgrNSPGAdUdIjSWXw+u/02BRTcnfw9PN41D2vq/JSEPnJnVuBgw18VkN8wcd4fjUs+jFHVM4t9+kBSNLw==}
@@ -840,6 +869,9 @@ packages:
   '@speed-highlight/core@1.2.12':
     resolution: {integrity: sha512-uilwrK0Ygyri5dToHYdZSjcvpS2ZwX0w5aSt3GCEN9hrjxWCoeV4Z2DTXuxjwbntaLQIEEAlCeNQss5SoHvAEA==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
@@ -852,6 +884,12 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/dompurify@3.2.0':
     resolution: {integrity: sha512-Fgg31wv9QbLDA0SpTOXO3MaxySc4DKGLi8sna4/Utjo4r3ZRPdCt4UQee8BWr+Q5z21yifghREPJGYaEOEIACg==}
     deprecated: This is a stub types definition. dompurify provides its own type definitions, so you do not need this installed.
@@ -861,6 +899,9 @@ packages:
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/node@25.9.1':
+    resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
 
   '@types/prop-types@15.7.15':
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
@@ -941,6 +982,35 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
+  '@vitest/expect@4.1.8':
+    resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
+
+  '@vitest/mocker@4.1.8':
+    resolution: {integrity: sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.8':
+    resolution: {integrity: sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==}
+
+  '@vitest/runner@4.1.8':
+    resolution: {integrity: sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==}
+
+  '@vitest/snapshot@4.1.8':
+    resolution: {integrity: sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==}
+
+  '@vitest/spy@4.1.8':
+    resolution: {integrity: sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==}
+
+  '@vitest/utils@4.1.8':
+    resolution: {integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1010,6 +1080,10 @@ packages:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
@@ -1061,6 +1135,10 @@ packages:
 
   caniuse-lite@1.0.30001757:
     resolution: {integrity: sha512-r0nnL/I28Zi/yjk1el6ilj27tKcdjLsNqAOZr0yVjWPrSQyHgKI2INaEWw21bAQSv2LXRt1XuCS/GomNpWOxsQ==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -1188,6 +1266,9 @@ packages:
     resolution: {integrity: sha512-uDn+FE1yrDzyC0pCo961B2IHbdM8y/ACZsKD4dG6WqrjV53BADjwa7D+1aom2rsNVfLyDgU/eigvlJGJ08OQ4w==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -1278,6 +1359,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -1288,6 +1372,10 @@ packages:
   exit-hook@2.2.1:
     resolution: {integrity: sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==}
     engines: {node: '>=6'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -1638,6 +1726,9 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -1712,6 +1803,10 @@ packages:
   object.values@1.2.1:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
+
+  obug@2.1.2:
+    resolution: {integrity: sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg==}
+    engines: {node: '>=12.20.0'}
 
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
@@ -1922,6 +2017,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -1936,6 +2034,12 @@ packages:
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -1996,9 +2100,20 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -2041,6 +2156,9 @@ packages:
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
+
+  undici-types@7.24.6:
+    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
   undici@7.14.0:
     resolution: {integrity: sha512-Vqs8HTzjpQXZeXdpsfChQTlafcMQaaIwnGwLam1wudSSjlJeQ3bw1j+TLPePgrCnCpUXx7Ba5Pdpf5OBih62NQ==}
@@ -2098,6 +2216,47 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.8:
+    resolution: {integrity: sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.8
+      '@vitest/browser-preview': 4.1.8
+      '@vitest/browser-webdriverio': 4.1.8
+      '@vitest/coverage-istanbul': 4.1.8
+      '@vitest/coverage-v8': 4.1.8
+      '@vitest/ui': 4.1.8
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
     engines: {node: '>= 0.4'}
@@ -2117,6 +2276,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -2727,6 +2891,8 @@ snapshots:
 
   '@speed-highlight/core@1.2.12': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.28.5
@@ -2748,6 +2914,13 @@ snapshots:
     dependencies:
       '@babel/types': 7.28.5
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
   '@types/dompurify@3.2.0':
     dependencies:
       dompurify: 3.3.3
@@ -2755,6 +2928,10 @@ snapshots:
   '@types/estree@1.0.8': {}
 
   '@types/json-schema@7.0.15': {}
+
+  '@types/node@25.9.1':
+    dependencies:
+      undici-types: 7.24.6
 
   '@types/prop-types@15.7.15': {}
 
@@ -2862,7 +3039,7 @@ snapshots:
       '@typescript-eslint/types': 8.48.0
       eslint-visitor-keys: 4.2.1
 
-  '@vitejs/plugin-react@4.7.0(vite@6.4.1(yaml@2.8.2))':
+  '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@25.9.1)(yaml@2.8.2))':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.5)
@@ -2870,9 +3047,50 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.4.1(yaml@2.8.2)
+      vite: 6.4.1(@types/node@25.9.1)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
+
+  '@vitest/expect@4.1.8':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.8(vite@6.4.1(@types/node@25.9.1)(yaml@2.8.2))':
+    dependencies:
+      '@vitest/spy': 4.1.8
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 6.4.1(@types/node@25.9.1)(yaml@2.8.2)
+
+  '@vitest/pretty-format@4.1.8':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.8':
+    dependencies:
+      '@vitest/utils': 4.1.8
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.8':
+    dependencies:
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/utils': 4.1.8
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.8': {}
+
+  '@vitest/utils@4.1.8':
+    dependencies:
+      '@vitest/pretty-format': 4.1.8
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
@@ -2962,6 +3180,8 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  assertion-error@2.0.1: {}
+
   async-function@1.0.0: {}
 
   available-typed-arrays@1.0.7:
@@ -3015,6 +3235,8 @@ snapshots:
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001757: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -3204,6 +3426,8 @@ snapshots:
       iterator.prototype: 1.1.5
       safe-array-concat: 1.1.3
 
+  es-module-lexer@2.1.0: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
@@ -3387,11 +3611,17 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
 
   eventemitter3@5.0.1: {}
 
   exit-hook@2.2.1: {}
+
+  expect-type@1.3.0: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -3741,6 +3971,10 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   math-intrinsics@1.1.0: {}
 
   micromatch@4.0.8:
@@ -3823,6 +4057,8 @@ snapshots:
       call-bound: 1.0.4
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
+
+  obug@2.1.2: {}
 
   onetime@7.0.0:
     dependencies:
@@ -4095,6 +4331,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   simple-swizzle@0.2.4:
@@ -4107,6 +4345,10 @@ snapshots:
       is-fullwidth-code-point: 5.1.0
 
   source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.1.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -4186,10 +4428,16 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.4: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinyrainbow@3.1.0: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -4248,6 +4496,8 @@ snapshots:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
 
+  undici-types@7.24.6: {}
+
   undici@7.14.0: {}
 
   unenv@2.0.0-rc.24:
@@ -4264,7 +4514,7 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  vite@6.4.1(yaml@2.8.2):
+  vite@6.4.1(@types/node@25.9.1)(yaml@2.8.2):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
@@ -4273,8 +4523,36 @@ snapshots:
       rollup: 4.53.3
       tinyglobby: 0.2.15
     optionalDependencies:
+      '@types/node': 25.9.1
       fsevents: 2.3.3
       yaml: 2.8.2
+
+  vitest@4.1.8(@types/node@25.9.1)(vite@6.4.1(@types/node@25.9.1)(yaml@2.8.2)):
+    dependencies:
+      '@vitest/expect': 4.1.8
+      '@vitest/mocker': 4.1.8(vite@6.4.1(@types/node@25.9.1)(yaml@2.8.2))
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/runner': 4.1.8
+      '@vitest/snapshot': 4.1.8
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.2
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 6.4.1(@types/node@25.9.1)(yaml@2.8.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.9.1
+    transitivePeerDependencies:
+      - msw
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -4320,6 +4598,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 


### PR DESCRIPTION
## 関連 Issue
closes #17

## 変更内容
- **commonSteps.ts**: `API_BASE` を `import.meta.env.DEV ? "http://localhost:8787" : "https://api.nostalgic.llll-ll.com"` に変更。dev/本番とも「表示しているURLをそのまま fetch する」が成立
- **全5サービスの `*Steps.tsx`**: `ENDPOINT` から誤った `/api` プレフィックスを除去（`/visit` `/like` `/bbs` `/ranking` `/yokoso`）
- **pages/{Counter,Like,BBS,Ranking,Yokoso}.tsx**: 相対 `/api/...` fetch を全て `${API_BASE}/...` のフルURLに置換（Like の batchGet POST、表示文言含む）。本番の Cloudflare Pages では相対パスが SPA フォールバックに飲まれて index.html が 200 で返る偽成功になっていた
- **embedConfigs.ts**: counter プレビューURLも同様に修正
- **vite.config.ts**: 不要になった `/api` dev プロキシを削除
- **docs**: user-guide 全サービス・webhook・README 等の `GET /api/visit?...` 表記と相対パス fetch 例（計約80箇所）を実パスに修正。コード例はコピペで動くフルURLに
- **テスト**: apps/web に vitest を最小導入し、URL構築の回帰テスト261件を追加（`buildApiUrl` の不変条件・optional パラメータ・エンコード・相対 `/api/` 再混入のソース走査ガード）

## 検証
- `pnpm --filter @nostalgic/web test` 261/261 pass
- `pnpm --filter @nostalgic/api test` 28/28 pass（API側は無変更）
- `pnpm --filter @nostalgic/web build` / `pnpm lint` 成功
- マージ・デプロイ後に本番 usage ページで golden path（作成→取得→削除）を実機確認予定