### PR TITLE
fix: usageページのAPIレスポンスを操作したフォームの直下にだけ表示

### DIFF
--- a/apps/web/src/__tests__/responseKeyMapping.test.ts
+++ b/apps/web/src/__tests__/responseKeyMapping.test.ts
@@ -1,0 +1,152 @@
+/**
+ * responseKey の一意性・相違・配線整合の回帰テスト (Issue #18)
+ *
+ * usage ページは step ごとに固有の responseKey を持ち、操作したフォームの
+ * 直下にだけレスポンスを表示する。複数の step が同じ responseKey を共有していると、
+ * 別フォームを操作した結果が無関係な step の下に表示される（#18 のバグ）。
+ *
+ * ここでは
+ *   1. 各サービスの steps 内で responseKey / id が一意であること
+ *   2. confirmId / updateAuthor / removeAuthor が create / 管理者操作と別キーであること
+ *   3. 各 step の handlerKey / responseKey が、対応するページの
+ *      handlers / responses マッピングに実在すること（source-scan）
+ * を機械的に検査する。
+ */
+
+import { describe, test, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import type { StepConfig } from "../config/commonSteps";
+import { counterSteps } from "../config/services/counterSteps";
+import { likeSteps } from "../config/services/likeSteps";
+import { rankingSteps } from "../config/services/rankingSteps";
+import { bbsSteps } from "../config/services/bbsSteps";
+import { yokosoSteps } from "../config/services/yokosoSteps";
+
+const PAGES_DIR = resolve(__dirname, "..", "pages");
+
+// 各サービスの steps 配列と、配線先のページソースファイル
+const SERVICES: { name: string; steps: StepConfig[]; pageFile: string }[] = [
+  { name: "counter", steps: counterSteps, pageFile: "Counter.tsx" },
+  { name: "like", steps: likeSteps, pageFile: "Like.tsx" },
+  { name: "ranking", steps: rankingSteps, pageFile: "Ranking.tsx" },
+  { name: "bbs", steps: bbsSteps, pageFile: "BBS.tsx" },
+  { name: "yokoso", steps: yokosoSteps, pageFile: "Yokoso.tsx" },
+];
+
+/**
+ * ページソースから `const NAME = { ... }` のオブジェクトリテラル直下の
+ * shorthand プロパティ名を抽出する。
+ * handlers / responses は shorthand（`handleCreate,` / `createResponse,`）で
+ * 書かれているため、`identifier,` または `identifier:` の形を拾えば十分。
+ */
+function extractObjectKeys(source: string, varName: string): Set<string> {
+  const start = source.indexOf(`const ${varName} = {`);
+  if (start < 0) {
+    throw new Error(`'const ${varName} = {' がページソースに見つからない`);
+  }
+  const open = source.indexOf("{", start);
+  // 最初の閉じ括弧 } までをブロックとみなす（handlers/responses はネストしない）
+  const close = source.indexOf("}", open);
+  const block = source.slice(open + 1, close);
+  const keys = new Set<string>();
+  for (const line of block.split("\n")) {
+    const m = line.trim().match(/^([A-Za-z_$][\w$]*)\s*[,:]/);
+    if (m) keys.add(m[1]);
+  }
+  return keys;
+}
+
+describe.each(SERVICES)("一意性: $name の steps", ({ steps }) => {
+  // 観点1: responseKey がサービス内で一意（#18 再発防止の本丸）
+  test("responseKey がサービス内で重複しない", () => {
+    const keys = steps.map((s) => s.responseKey);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  // 観点2: id もサービス内で一意（保険）
+  test("id がサービス内で重複しない", () => {
+    const ids = steps.map((s) => s.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe("相違: counter / like の confirmId step", () => {
+  for (const { name, steps } of [
+    { name: "counter", steps: counterSteps },
+    { name: "like", steps: likeSteps },
+  ]) {
+    const confirmId = steps.find((s) => s.id === "confirmId");
+    const create = steps.find((s) => s.id === "create");
+
+    // 観点3: confirmId step が存在する
+    test(`${name}: confirmId step が存在する`, () => {
+      expect(confirmId).toBeDefined();
+      expect(create).toBeDefined();
+    });
+
+    // 観点3: confirmId の responseKey が専用キーで、create と異なる
+    test(`${name}: confirmId.responseKey は confirmIdResponse で create と異なる`, () => {
+      expect(confirmId!.responseKey).toBe("confirmIdResponse");
+      expect(confirmId!.responseKey).not.toBe(create!.responseKey);
+    });
+
+    // 観点3: confirmId の handlerKey が専用ハンドラで、create と異なる
+    test(`${name}: confirmId.handlerKey は handleConfirmId で create と異なる`, () => {
+      expect(confirmId!.handlerKey).toBe("handleConfirmId");
+      expect(confirmId!.handlerKey).not.toBe(create!.handlerKey);
+    });
+  }
+});
+
+describe("相違: bbs の author 操作 vs admin 操作", () => {
+  const get = (id: string) => {
+    const step = bbsSteps.find((s) => s.id === id);
+    expect(step, `bbs step '${id}' が存在する`).toBeDefined();
+    return step!;
+  };
+
+  // 観点4: updateAuthor と updateSettings(管理者) の responseKey が異なる
+  test("updateAuthor の responseKey は admin 系 update と異なる", () => {
+    const updateAuthor = get("updateAuthor");
+    const updateAdmin = get("updateSettings");
+    expect(updateAuthor.responseKey).toBe("updateAuthorResponse");
+    expect(updateAuthor.responseKey).not.toBe(updateAdmin.responseKey);
+  });
+
+  // 観点4: removeAuthor と delete(管理者) の responseKey が異なる
+  test("removeAuthor の responseKey は admin 系 remove/delete と異なる", () => {
+    const removeAuthor = get("removeAuthor");
+    const removeAdmin = get("delete");
+    expect(removeAuthor.responseKey).toBe("removeAuthorResponse");
+    expect(removeAuthor.responseKey).not.toBe(removeAdmin.responseKey);
+  });
+});
+
+describe.each(SERVICES)("配線整合: $name の steps とページ", ({ steps, pageFile }) => {
+  const source = readFileSync(resolve(PAGES_DIR, pageFile), "utf8");
+  const handlerKeys = extractObjectKeys(source, "handlers");
+  const responseKeys = extractObjectKeys(source, "responses");
+
+  // 走査が空振りしていないことの保証
+  test("ページの handlers / responses からキーを抽出できる", () => {
+    expect(handlerKeys.size).toBeGreaterThan(0);
+    expect(responseKeys.size).toBeGreaterThan(0);
+  });
+
+  // 観点5: 各 step の handlerKey がページの handlers に実在する
+  test.each(steps.map((s) => [s.id, s.handlerKey] as const))(
+    "step '%s' の handlerKey '%s' がページの handlers に存在する",
+    (_id, handlerKey) => {
+      expect(handlerKeys.has(handlerKey)).toBe(true);
+    }
+  );
+
+  // 観点5: 各 step の responseKey がページの responses に実在する
+  test.each(steps.map((s) => [s.id, s.responseKey] as const))(
+    "step '%s' の responseKey '%s' がページの responses に存在する",
+    (_id, responseKey) => {
+      expect(responseKeys.has(responseKey)).toBe(true);
+    }
+  );
+});

--- a/apps/web/src/config/services/bbsSteps.tsx
+++ b/apps/web/src/config/services/bbsSteps.tsx
@@ -305,7 +305,7 @@ const updateAuthorStep: StepConfig = {
   ],
   buttonText: "編集",
   handlerKey: "handleEditMessageById",
-  responseKey: "updateResponse",
+  responseKey: "updateAuthorResponse",
   buildApiUrl: (values) => {
     const id = values.publicId || "公開ID";
     const messageId = values.messageId || "メッセージID";
@@ -339,7 +339,7 @@ const removeAuthorStep: StepConfig = {
   ],
   buttonText: "削除",
   handlerKey: "handleDeleteMessageById",
-  responseKey: "removeResponse",
+  responseKey: "removeAuthorResponse",
   buildApiUrl: (values) => {
     const id = values.publicId || "公開ID";
     const messageId = values.messageId || "メッセージID";

--- a/apps/web/src/config/services/counterSteps.tsx
+++ b/apps/web/src/config/services/counterSteps.tsx
@@ -65,8 +65,8 @@ const confirmIdStep: StepConfig = {
   isOwnerStep: true,
   fields: [COMMON_FIELDS.url, COMMON_FIELDS.token],
   buttonText: "公開ID確認",
-  handlerKey: "handleCreate",
-  responseKey: "createResponse",
+  handlerKey: "handleConfirmId",
+  responseKey: "confirmIdResponse",
   buildApiUrl: (values) => {
     const url = values.url || "サイトURL";
     const token = values.token || "オーナートークン";

--- a/apps/web/src/config/services/likeSteps.tsx
+++ b/apps/web/src/config/services/likeSteps.tsx
@@ -78,8 +78,8 @@ const confirmIdStep: StepConfig = {
   isOwnerStep: true,
   fields: [COMMON_FIELDS.url, COMMON_FIELDS.token],
   buttonText: "公開ID確認",
-  handlerKey: "handleCreate",
-  responseKey: "createResponse",
+  handlerKey: "handleConfirmId",
+  responseKey: "confirmIdResponse",
   buildApiUrl: (values) => {
     const url = values.url || "サイトURL";
     const token = values.token || "オーナートークン";

--- a/apps/web/src/pages/BBS.tsx
+++ b/apps/web/src/pages/BBS.tsx
@@ -74,6 +74,8 @@ export default function BBSPage() {
   const [getResponse, setGetResponse] = useState("");
   const [updateResponse, setUpdateResponse] = useState("");
   const [removeResponse, setRemoveResponse] = useState("");
+  const [updateAuthorResponse, setUpdateAuthorResponse] = useState("");
+  const [removeAuthorResponse, setRemoveAuthorResponse] = useState("");
   const [clearResponse, setClearResponse] = useState("");
   const [deleteResponse, setDeleteResponse] = useState("");
   const [updateSettingsResponse, setUpdateSettingsResponse] = useState("");
@@ -217,7 +219,7 @@ export default function BBSPage() {
     if (!publicId || !messageId || !editMessage) return;
 
     const apiUrl = `${API_BASE}/bbs?action=update&id=${encodeURIComponent(publicId)}&messageId=${messageId}&message=${encodeURIComponent(editMessage)}`;
-    await callApi(apiUrl, setUpdateResponse);
+    await callApi(apiUrl, setUpdateAuthorResponse);
   };
 
   const handleDeleteMessageById = async (e: React.FormEvent) => {
@@ -225,7 +227,7 @@ export default function BBSPage() {
     if (!publicId || !messageId) return;
 
     const apiUrl = `${API_BASE}/bbs?action=remove&id=${encodeURIComponent(publicId)}&messageId=${messageId}`;
-    await callApi(apiUrl, setRemoveResponse);
+    await callApi(apiUrl, setRemoveAuthorResponse);
   };
 
   const handlers = {
@@ -249,6 +251,8 @@ export default function BBSPage() {
     getResponse,
     updateResponse,
     removeResponse,
+    updateAuthorResponse,
+    removeAuthorResponse,
     clearResponse,
     deleteResponse,
     updateSettingsResponse,

--- a/apps/web/src/pages/Counter.tsx
+++ b/apps/web/src/pages/Counter.tsx
@@ -24,6 +24,7 @@ export default function CounterPage() {
 
   // Response state
   const [createResponse, setCreateResponse] = useState("");
+  const [confirmIdResponse, setConfirmIdResponse] = useState("");
   const [displayResponse, setDisplayResponse] = useState("");
   const [incrementResponse, setIncrementResponse] = useState("");
   const [getResponse, setGetResponse] = useState("");
@@ -55,6 +56,16 @@ export default function CounterPage() {
     if (webhookUrl) apiUrl += `&webhookUrl=${encodeURIComponent(webhookUrl)}`;
 
     await callApi(apiUrl, setCreateResponse, setPublicId);
+  };
+
+  const handleConfirmId = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!url || !token) return;
+
+    let apiUrl = `${API_BASE}/visit?action=create&url=${encodeURIComponent(url)}&token=${encodeURIComponent(token)}`;
+    if (webhookUrl) apiUrl += `&webhookUrl=${encodeURIComponent(webhookUrl)}`;
+
+    await callApi(apiUrl, setConfirmIdResponse, setPublicId);
   };
 
   const handleDisplay = async (e: React.FormEvent) => {
@@ -114,6 +125,7 @@ export default function CounterPage() {
 
   const handlers = {
     handleCreate,
+    handleConfirmId,
     handleDisplay,
     handleIncrement,
     handleGet,
@@ -124,6 +136,7 @@ export default function CounterPage() {
 
   const responses = {
     createResponse,
+    confirmIdResponse,
     displayResponse,
     incrementResponse,
     getResponse,

--- a/apps/web/src/pages/Like.tsx
+++ b/apps/web/src/pages/Like.tsx
@@ -46,6 +46,7 @@ export default function LikePage() {
 
   // Response state
   const [createResponse, setCreateResponse] = useState("");
+  const [confirmIdResponse, setConfirmIdResponse] = useState("");
   const [displayResponse, setDisplayResponse] = useState("");
   const [toggleResponse, setToggleResponse] = useState("");
   const [getResponse, setGetResponse] = useState("");
@@ -79,6 +80,16 @@ export default function LikePage() {
     if (webhookUrl) apiUrl += `&webhookUrl=${encodeURIComponent(webhookUrl)}`;
 
     await callApi(apiUrl, setCreateResponse, setPublicId);
+  };
+
+  const handleConfirmId = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!url || !token) return;
+
+    let apiUrl = `${API_BASE}/like?action=create&url=${encodeURIComponent(url)}&token=${encodeURIComponent(token)}`;
+    if (webhookUrl) apiUrl += `&webhookUrl=${encodeURIComponent(webhookUrl)}`;
+
+    await callApi(apiUrl, setConfirmIdResponse, setPublicId);
   };
 
   const handleDisplay = async (e: React.FormEvent) => {
@@ -154,6 +165,7 @@ export default function LikePage() {
 
   const handlers = {
     handleCreate,
+    handleConfirmId,
     handleDisplay,
     handleToggle,
     handleGet,
@@ -163,6 +175,7 @@ export default function LikePage() {
 
   const responses = {
     createResponse,
+    confirmIdResponse,
     displayResponse,
     toggleResponse,
     getResponse,


### PR DESCRIPTION
## 関連 Issue
closes #18

## 変更内容
- **counterSteps / likeSteps**: `confirmId` step に固有の `handlerKey: handleConfirmId` / `responseKey: confirmIdResponse` を割当（従来は create と `handleCreate`/`createResponse` を共有しており、片方の実行結果が両方の直下に表示されていた）
- **bbsSteps**: `updateAuthor` → `updateAuthorResponse`、`removeAuthor` → `removeAuthorResponse` に分離（管理者用フォームとの混線解消。handler は元から別）
- **Counter.tsx / Like.tsx**: `handleConfirmId` と `confirmIdResponse` state を新設（同じ create API を叩くが書き込み先を分離）
- **BBS.tsx**: author 系 handler の書き込み先 state を新キーに付替え
- **テスト**: `responseKeyMapping.test.ts` を新規追加（105件）— 全サービスの responseKey 一意性、confirmId/create の分離、pages との配線整合（source-scan）。逆挿入で検出有効性を確認済み

ranking / yokoso は元から全 step 固有のため無変更。

## 検証
- web テスト 366/366 pass（261 + 新規105）
- API テスト 28/28 pass（API側無変更）
- build / lint 成功
- マージ・デプロイ後に本番で「create 実行 → confirmId の直下に出ない」を実機確認予定