### PR TITLE
feat: APIの未捕捉エラーを観測可能にし、create の D1 例外を正規化

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,11 +1,11 @@
 import { Hono } from "hono";
 import { cors } from "hono/cors";
 
-import visitRoute from "./routes/visit";
-import likeRoute from "./routes/like";
-import rankingRoute from "./routes/ranking";
-import bbsRoute from "./routes/bbs";
-import yokosoRoute from "./routes/yokoso";
+import visitRoute from "./routes/visit.ts";
+import likeRoute from "./routes/like.ts";
+import rankingRoute from "./routes/ranking.ts";
+import bbsRoute from "./routes/bbs.ts";
+import yokosoRoute from "./routes/yokoso.ts";
 
 type Bindings = {
   DB: D1Database;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -86,4 +86,17 @@ app.route("/ranking", rankingRoute);
 app.route("/bbs", bbsRoute);
 app.route("/yokoso", yokosoRoute);
 
+// 未捕捉エラーの観測性 + レスポンスを JSON に統一（Hono 既定の text/plain をやめる）。
+// token 等の機微 query は丸ごと出さず、method / path / action のみログに残す。err 本体は出す。
+app.onError((err, c) => {
+  console.error(
+    "[nostalgic-api] unhandled error:",
+    c.req.method,
+    c.req.path,
+    c.req.query("action"),
+    err
+  );
+  return c.json({ error: "Internal Server Error" }, 500);
+});
+
 export default app;

--- a/apps/api/src/lib/core/index.ts
+++ b/apps/api/src/lib/core/index.ts
@@ -6,3 +6,4 @@ export * from "./id";
 export * from "./db";
 export * from "./constants";
 export * from "./batch";
+export * from "./storage";

--- a/apps/api/src/lib/core/storage.test.ts
+++ b/apps/api/src/lib/core/storage.test.ts
@@ -1,0 +1,76 @@
+/**
+ * storage.ts のユニットテスト
+ *
+ * runCreateBatch の 3 分岐を D1 の最小 fake で検証する。
+ * - UNIQUE 制約違反 → AlreadyExistsError（呼び出し側が 400 already-exists に変換できる形）
+ * - それ以外の D1 例外 → そのまま透過再 throw（app.onError が 500 に集約する前提を崩さない）
+ * - 正常 → resolve（追加の戻り値を作らない）
+ * isUniqueConstraintError の判定境界も併せて確認する。
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { runCreateBatch, AlreadyExistsError, isUniqueConstraintError } from "./storage.ts";
+
+/** batch() の挙動だけ差し替えられる最小 fake D1 */
+function fakeDb(batchImpl: () => Promise<unknown>): D1Database {
+  return {
+    batch: batchImpl,
+  } as unknown as D1Database;
+}
+
+const dummyStatements = [] as unknown as D1PreparedStatement[];
+
+test("runCreateBatch: UNIQUE 制約違反は AlreadyExistsError に変換される", async () => {
+  const db = fakeDb(() => Promise.reject(new Error("UNIQUE constraint failed: url_mappings.url")));
+
+  await assert.rejects(
+    () => runCreateBatch(db, dummyStatements, "Counter already exists for this URL"),
+    (err: unknown) => {
+      assert.ok(err instanceof AlreadyExistsError, "AlreadyExistsError で投げ直す");
+      assert.equal((err as AlreadyExistsError).message, "Counter already exists for this URL");
+      assert.equal((err as AlreadyExistsError).name, "AlreadyExistsError");
+      return true;
+    }
+  );
+});
+
+test("runCreateBatch: UNIQUE 以外の D1 例外はそのまま透過再 throw される", async () => {
+  // FOREIGN KEY 違反などは already-exists ではないので握りつぶさず、元のエラーを保つ。
+  const original = new Error("FOREIGN KEY constraint failed");
+  const db = fakeDb(() => Promise.reject(original));
+
+  await assert.rejects(
+    () => runCreateBatch(db, dummyStatements, "Counter already exists for this URL"),
+    (err: unknown) => {
+      assert.equal(err, original, "同一インスタンスがそのまま伝播する");
+      assert.ok(!(err instanceof AlreadyExistsError), "AlreadyExistsError に化けない");
+      return true;
+    }
+  );
+});
+
+test("runCreateBatch: 正常時は resolve し例外を投げない", async () => {
+  let called = false;
+  const db = fakeDb(() => {
+    called = true;
+    return Promise.resolve([{ success: true }]);
+  });
+
+  await assert.doesNotReject(() =>
+    runCreateBatch(db, dummyStatements, "Counter already exists for this URL")
+  );
+  assert.equal(called, true, "batch が実際に実行される");
+});
+
+test("isUniqueConstraintError: UNIQUE 文言を含む Error のみ true", async () => {
+  assert.equal(
+    isUniqueConstraintError(new Error("UNIQUE constraint failed: url_mappings.url")),
+    true
+  );
+  assert.equal(isUniqueConstraintError("UNIQUE constraint failed: services.id"), true);
+  assert.equal(isUniqueConstraintError(new Error("FOREIGN KEY constraint failed")), false);
+  assert.equal(isUniqueConstraintError(new Error("D1_ERROR: no such table")), false);
+  assert.equal(isUniqueConstraintError(null), false);
+  assert.equal(isUniqueConstraintError(undefined), false);
+});

--- a/apps/api/src/lib/core/storage.ts
+++ b/apps/api/src/lib/core/storage.ts
@@ -1,0 +1,46 @@
+/**
+ * D1 書き込みの共通ハンドリング
+ *
+ * create 系で起きうる UNIQUE 制約違反（事前の existence チェックと
+ * 実 INSERT の間に同一 URL/id が作られる競合）を、既存の
+ * already-exists 応答（400）と同じ形に正規化するためのヘルパー。
+ * それ以外の D1 例外はそのまま投げ直し、app.onError で 500 JSON に集約する。
+ */
+
+/** D1 が返す UNIQUE 制約違反かどうかを判定する */
+export function isUniqueConstraintError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : typeof err === "string" ? err : String(err);
+  return message.includes("UNIQUE constraint failed");
+}
+
+/** create 系の競合（UNIQUE 違反）を already-exists として扱うためのエラー */
+export class AlreadyExistsError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AlreadyExistsError";
+  }
+}
+
+/**
+ * create の INSERT バッチを実行し、UNIQUE 制約違反を AlreadyExistsError に変換する。
+ * - UNIQUE 違反 → AlreadyExistsError（呼び出し側で 400 already-exists 応答に変換）
+ * - それ以外の例外 → そのまま再 throw（app.onError が 500 JSON に集約）
+ *
+ * @param db          D1Database
+ * @param statements  実行する INSERT ステートメント配列
+ * @param conflictMessage UNIQUE 違反時に投げる already-exists メッセージ
+ */
+export async function runCreateBatch(
+  db: D1Database,
+  statements: D1PreparedStatement[],
+  conflictMessage: string
+): Promise<void> {
+  try {
+    await db.batch(statements);
+  } catch (err) {
+    if (isUniqueConstraintError(err)) {
+      throw new AlreadyExistsError(conflictMessage);
+    }
+    throw err;
+  }
+}

--- a/apps/api/src/lib/core/storage.ts
+++ b/apps/api/src/lib/core/storage.ts
@@ -10,6 +10,9 @@
 /** D1 が返す UNIQUE 制約違反かどうかを判定する */
 export function isUniqueConstraintError(err: unknown): boolean {
   const message = err instanceof Error ? err.message : typeof err === "string" ? err : String(err);
+  // SQLite/D1 は PRIMARY KEY 違反も "UNIQUE constraint failed: <table>.<col>" として
+  // 報告するため、この判定は PK 競合（url_mappings の複合PK等）もカバーする。
+  // D1_ERROR: プレフィックスが付く場合も substring 一致で拾える。
   return message.includes("UNIQUE constraint failed");
 }
 

--- a/apps/api/src/routes/bbs.ts
+++ b/apps/api/src/routes/bbs.ts
@@ -22,6 +22,7 @@ import { generatePublicId } from "../lib/core/id.ts";
 import { generateUserHash } from "../lib/core/crypto.ts";
 import { BBS } from "../lib/core/constants.ts";
 import { sendWebHook, WebHookMessages } from "../lib/core/webhook.ts";
+import { runCreateBatch, AlreadyExistsError } from "../lib/core/storage.ts";
 import { batchLookupServices, lookupService, MAX_LOOKUP_BATCH_SIZE } from "../lib/core/lookup.ts";
 
 type Bindings = { DB: D1Database };
@@ -334,19 +335,30 @@ async function handleBBSAction(c: AppContext) {
         : null,
     });
 
-    await db.batch([
-      db
-        .prepare(
-          'INSERT INTO services (id, type, url, metadata, created_at) VALUES (?, ?, ?, ?, datetime("now"))'
-        )
-        .bind(`bbs:${publicId}`, "bbs", url, metadata),
-      db
-        .prepare("INSERT INTO url_mappings (type, url, service_id) VALUES (?, ?, ?)")
-        .bind("bbs", url, publicId),
-      db
-        .prepare("INSERT INTO owner_tokens (service_id, token_hash) VALUES (?, ?)")
-        .bind(`bbs:${publicId}`, hashedToken),
-    ]);
+    try {
+      await runCreateBatch(
+        db,
+        [
+          db
+            .prepare(
+              'INSERT INTO services (id, type, url, metadata, created_at) VALUES (?, ?, ?, ?, datetime("now"))'
+            )
+            .bind(`bbs:${publicId}`, "bbs", url, metadata),
+          db
+            .prepare("INSERT INTO url_mappings (type, url, service_id) VALUES (?, ?, ?)")
+            .bind("bbs", url, publicId),
+          db
+            .prepare("INSERT INTO owner_tokens (service_id, token_hash) VALUES (?, ?)")
+            .bind(`bbs:${publicId}`, hashedToken),
+        ],
+        "BBS already exists for this URL"
+      );
+    } catch (err) {
+      if (err instanceof AlreadyExistsError) {
+        return c.json({ error: err.message }, 400);
+      }
+      throw err;
+    }
 
     return c.json({ success: true, id: publicId, url, title, maxMessages, messagesPerPage });
   }

--- a/apps/api/src/routes/error-handling.test.ts
+++ b/apps/api/src/routes/error-handling.test.ts
@@ -1,0 +1,182 @@
+/**
+ * create の例外正規化 + app.onError の結合テスト
+ *
+ * 事前 existence チェック（getXxxByUrl 等）は通過させ（first() が null を返す fake）、
+ * 実 INSERT の db.batch() で例外を起こして、ルート層の振る舞いを検証する。
+ *
+ * - UNIQUE 違反: create が既存 already-exists と同じ 400 JSON を返す（visit / bbs で代表確認）
+ * - batchCreate: 競合 1 件が skipped にカウントされ created に入らない（visit / like）
+ * - 非 UNIQUE の DB 例外（FOREIGN KEY）: app.onError が 500 / JSON / {"error":"Internal Server Error"}
+ * - ログ汚染防止: console.error に統一プレフィックスが出て、かつ token 値が混ざらない
+ * - 正常系: batch 成功時に create が 200 成功 JSON を返す
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import visitApp from "./visit.ts";
+import likeApp from "./like.ts";
+import bbsApp from "./bbs.ts";
+import app from "../index.ts";
+
+/**
+ * 最小 fake D1。
+ * - prepare().bind().first() は常に null（= 事前 existence チェックは「存在しない」を返す）
+ * - prepare().bind().all() は空（batchCreate のループ前チェック用に一応用意）
+ * - batch() は注入した挙動を使う。callIndex で複数回の挙動を出し分けられる
+ */
+function makeFakeDb(batchImpl: (callIndex: number) => Promise<unknown>): { db: D1Database } {
+  let batchCount = 0;
+  const stmt = {
+    bind: () => ({
+      first: async () => null,
+      all: async () => ({ results: [] }),
+      run: async () => ({ success: true }),
+    }),
+  };
+  const db = {
+    prepare: () => stmt,
+    batch: () => {
+      const idx = batchCount;
+      batchCount++;
+      return batchImpl(idx);
+    },
+  } as unknown as D1Database;
+  return { db };
+}
+
+const uniqueError = () => Promise.reject(new Error("UNIQUE constraint failed: url_mappings.url"));
+const foreignKeyError = () => Promise.reject(new Error("FOREIGN KEY constraint failed"));
+const batchOk = () => Promise.resolve([{ success: true }]);
+
+const VALID_TOKEN = "valid-token-12"; // 8-16 文字
+
+function postInit(body: unknown): RequestInit {
+  return {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  };
+}
+
+test("結合: visit create の UNIQUE 違反は既存 already-exists と同じ 400 JSON を返す", async () => {
+  const { db } = makeFakeDb(uniqueError);
+  const res = await visitApp.request(
+    `/?action=create&url=https://example.com/visit&token=${VALID_TOKEN}`,
+    { method: "GET" },
+    { DB: db }
+  );
+  assert.equal(res.status, 400);
+  const json = (await res.json()) as { error?: string };
+  assert.equal(json.error, "Counter already exists for this URL");
+});
+
+test("結合: bbs create の UNIQUE 違反は既存 already-exists と同じ 400 JSON を返す", async () => {
+  const { db } = makeFakeDb(uniqueError);
+  const res = await bbsApp.request(
+    `/?action=create&url=https://example.com/bbs&token=${VALID_TOKEN}`,
+    { method: "GET" },
+    { DB: db }
+  );
+  assert.equal(res.status, 400);
+  const json = (await res.json()) as { error?: string };
+  assert.equal(json.error, "BBS already exists for this URL");
+});
+
+test("結合: visit batchCreate は競合 1 件を skipped に数え created に入れない", async () => {
+  // 2 件目の batch だけ UNIQUE 違反させる（1 件目は成功）。
+  const { db } = makeFakeDb((idx) => (idx === 1 ? uniqueError() : batchOk()));
+  const res = await visitApp.request(
+    "/?action=batchCreate",
+    postInit({
+      token: VALID_TOKEN,
+      items: [
+        { id: "alpha", url: "https://example.com/a" },
+        { id: "beta", url: "https://example.com/b" },
+      ],
+    }),
+    { DB: db }
+  );
+  assert.equal(res.status, 200);
+  const json = (await res.json()) as { success: boolean; created: number; skipped: number };
+  assert.equal(json.success, true);
+  assert.equal(json.created, 1, "成功した 1 件だけ created");
+  assert.equal(json.skipped, 1, "競合 1 件は skipped");
+});
+
+test("結合: like batchCreate は競合 1 件を skipped に数え created に入れない", async () => {
+  const { db } = makeFakeDb((idx) => (idx === 1 ? uniqueError() : batchOk()));
+  const res = await likeApp.request(
+    "/?action=batchCreate",
+    postInit({
+      token: VALID_TOKEN,
+      items: [
+        { id: "alpha", url: "https://example.com/a" },
+        { id: "beta", url: "https://example.com/b" },
+      ],
+    }),
+    { DB: db }
+  );
+  assert.equal(res.status, 200);
+  const json = (await res.json()) as { success: boolean; created: number; skipped: number };
+  assert.equal(json.success, true);
+  assert.equal(json.created, 1);
+  assert.equal(json.skipped, 1);
+});
+
+test("結合: 非 UNIQUE の DB 例外は onError で 500 / application/json / 規定 body になる", async () => {
+  // 本物の index app を使い、Hono 既定の text/plain ではなく JSON で返ることを保証する。
+  const { db } = makeFakeDb(foreignKeyError);
+  const originalError = console.error;
+  console.error = () => {}; // この test では本筋でないので黙らせる
+  try {
+    const res = await app.request(
+      `/visit?action=create&url=https://example.com/fk&token=${VALID_TOKEN}`,
+      { method: "GET" },
+      { DB: db }
+    );
+    assert.equal(res.status, 500);
+    assert.equal(res.headers.get("content-type"), "application/json");
+    const json = (await res.json()) as { error?: string };
+    assert.deepEqual(json, { error: "Internal Server Error" });
+  } finally {
+    console.error = originalError;
+  }
+});
+
+test("結合: onError ログは統一プレフィックスを出し、token 値を含めない", async () => {
+  const { db } = makeFakeDb(foreignKeyError);
+  const captured: string[] = [];
+  const originalError = console.error;
+  console.error = (...args: unknown[]) => {
+    captured.push(args.map((a) => (a instanceof Error ? a.message : String(a))).join(" "));
+  };
+  try {
+    const res = await app.request(
+      `/visit?action=create&url=https://example.com/fk2&token=${VALID_TOKEN}`,
+      { method: "GET" },
+      { DB: db }
+    );
+    assert.equal(res.status, 500);
+  } finally {
+    console.error = originalError;
+  }
+
+  const joined = captured.join("\n");
+  assert.ok(joined.includes("[nostalgic-api] unhandled error:"), "統一プレフィックスでログされる");
+  assert.ok(joined.includes("create"), "action はログに残る（観測性）");
+  assert.ok(!joined.includes(VALID_TOKEN), "token 値はログに漏れない");
+});
+
+test("結合: visit create は batch 成功時に 200 成功 JSON を返す", async () => {
+  const { db } = makeFakeDb(batchOk);
+  const res = await visitApp.request(
+    `/?action=create&url=https://example.com/ok&token=${VALID_TOKEN}`,
+    { method: "GET" },
+    { DB: db }
+  );
+  assert.equal(res.status, 200);
+  const json = (await res.json()) as { success?: boolean; message?: string; id?: string };
+  assert.equal(json.success, true);
+  assert.equal(json.message, "Counter created successfully");
+  assert.ok(typeof json.id === "string" && json.id.length > 0, "id が払い出される");
+});

--- a/apps/api/src/routes/like.ts
+++ b/apps/api/src/routes/like.ts
@@ -23,6 +23,7 @@ import { getTodayDateString } from "../lib/core/db.ts";
 import { URL_CONST } from "../lib/core/constants.ts";
 import { chunkArray, BATCH_GET_CHUNK_SIZE } from "../lib/core/batch.ts";
 import { sendWebHook, WebHookMessages } from "../lib/core/webhook.ts";
+import { runCreateBatch, AlreadyExistsError } from "../lib/core/storage.ts";
 
 type Bindings = { DB: D1Database };
 
@@ -286,22 +287,33 @@ async function handleLikeAction(c: AppContext) {
       icon: icon || "heart",
     });
 
-    await db.batch([
-      db
-        .prepare(
-          'INSERT INTO services (id, type, url, metadata, created_at) VALUES (?, ?, ?, ?, datetime("now"))'
-        )
-        .bind(`like:${publicId}`, "like", url, metadata),
-      db
-        .prepare("INSERT INTO url_mappings (type, url, service_id) VALUES (?, ?, ?)")
-        .bind("like", url, publicId),
-      db
-        .prepare("INSERT INTO owner_tokens (service_id, token_hash) VALUES (?, ?)")
-        .bind(`like:${publicId}`, hashedToken),
-      db
-        .prepare("INSERT INTO likes (service_id, total) VALUES (?, 0)")
-        .bind(`like:${publicId}:total`),
-    ]);
+    try {
+      await runCreateBatch(
+        db,
+        [
+          db
+            .prepare(
+              'INSERT INTO services (id, type, url, metadata, created_at) VALUES (?, ?, ?, ?, datetime("now"))'
+            )
+            .bind(`like:${publicId}`, "like", url, metadata),
+          db
+            .prepare("INSERT INTO url_mappings (type, url, service_id) VALUES (?, ?, ?)")
+            .bind("like", url, publicId),
+          db
+            .prepare("INSERT INTO owner_tokens (service_id, token_hash) VALUES (?, ?)")
+            .bind(`like:${publicId}`, hashedToken),
+          db
+            .prepare("INSERT INTO likes (service_id, total) VALUES (?, 0)")
+            .bind(`like:${publicId}:total`),
+        ],
+        "Like service already exists for this URL"
+      );
+    } catch (err) {
+      if (err instanceof AlreadyExistsError) {
+        return c.json({ error: err.message }, 400);
+      }
+      throw err;
+    }
 
     return c.json({ success: true, id: publicId, url });
   }
@@ -509,22 +521,35 @@ async function handleLikeAction(c: AppContext) {
 
       const metadata = JSON.stringify({ webhookUrl: null, icon: "heart" });
 
-      await db.batch([
-        db
-          .prepare(
-            'INSERT INTO services (id, type, url, metadata, created_at) VALUES (?, ?, ?, ?, datetime("now"))'
-          )
-          .bind(`like:${item.id}`, "like", item.url, metadata),
-        db
-          .prepare("INSERT INTO url_mappings (type, url, service_id) VALUES (?, ?, ?)")
-          .bind("like", item.url, item.id),
-        db
-          .prepare("INSERT INTO owner_tokens (service_id, token_hash) VALUES (?, ?)")
-          .bind(`like:${item.id}`, hashedToken),
-        db
-          .prepare("INSERT INTO likes (service_id, total) VALUES (?, 0)")
-          .bind(`like:${item.id}:total`),
-      ]);
+      try {
+        await runCreateBatch(
+          db,
+          [
+            db
+              .prepare(
+                'INSERT INTO services (id, type, url, metadata, created_at) VALUES (?, ?, ?, ?, datetime("now"))'
+              )
+              .bind(`like:${item.id}`, "like", item.url, metadata),
+            db
+              .prepare("INSERT INTO url_mappings (type, url, service_id) VALUES (?, ?, ?)")
+              .bind("like", item.url, item.id),
+            db
+              .prepare("INSERT INTO owner_tokens (service_id, token_hash) VALUES (?, ?)")
+              .bind(`like:${item.id}`, hashedToken),
+            db
+              .prepare("INSERT INTO likes (service_id, total) VALUES (?, 0)")
+              .bind(`like:${item.id}:total`),
+          ],
+          `Like service already exists: ${item.id}`
+        );
+      } catch (err) {
+        // 事前チェックと INSERT の間の競合は skip 扱い（既存の skip 意味論に合わせる）
+        if (err instanceof AlreadyExistsError) {
+          skipped++;
+          continue;
+        }
+        throw err;
+      }
       created++;
     }
 

--- a/apps/api/src/routes/ranking.ts
+++ b/apps/api/src/routes/ranking.ts
@@ -22,6 +22,7 @@ import { generatePublicId } from "../lib/core/id.ts";
 import { generateUserHash } from "../lib/core/crypto.ts";
 import { RANKING } from "../lib/core/constants.ts";
 import { sendWebHook, WebHookMessages } from "../lib/core/webhook.ts";
+import { runCreateBatch, AlreadyExistsError } from "../lib/core/storage.ts";
 import { batchLookupServices, lookupService, MAX_LOOKUP_BATCH_SIZE } from "../lib/core/lookup.ts";
 
 type Bindings = { DB: D1Database };
@@ -295,19 +296,30 @@ async function handleRankingAction(c: AppContext) {
       webhookUrl: webhookUrl || null,
     });
 
-    await db.batch([
-      db
-        .prepare(
-          'INSERT INTO services (id, type, url, metadata, created_at) VALUES (?, ?, ?, ?, datetime("now"))'
-        )
-        .bind(`ranking:${publicId}`, "ranking", url, metadata),
-      db
-        .prepare("INSERT INTO url_mappings (type, url, service_id) VALUES (?, ?, ?)")
-        .bind("ranking", url, publicId),
-      db
-        .prepare("INSERT INTO owner_tokens (service_id, token_hash) VALUES (?, ?)")
-        .bind(`ranking:${publicId}`, hashedToken),
-    ]);
+    try {
+      await runCreateBatch(
+        db,
+        [
+          db
+            .prepare(
+              'INSERT INTO services (id, type, url, metadata, created_at) VALUES (?, ?, ?, ?, datetime("now"))'
+            )
+            .bind(`ranking:${publicId}`, "ranking", url, metadata),
+          db
+            .prepare("INSERT INTO url_mappings (type, url, service_id) VALUES (?, ?, ?)")
+            .bind("ranking", url, publicId),
+          db
+            .prepare("INSERT INTO owner_tokens (service_id, token_hash) VALUES (?, ?)")
+            .bind(`ranking:${publicId}`, hashedToken),
+        ],
+        "Ranking already exists for this URL"
+      );
+    } catch (err) {
+      if (err instanceof AlreadyExistsError) {
+        return c.json({ error: err.message }, 400);
+      }
+      throw err;
+    }
 
     return c.json({ success: true, id: publicId, url, title, sortOrder, maxEntries });
   }

--- a/apps/api/src/routes/visit.ts
+++ b/apps/api/src/routes/visit.ts
@@ -25,6 +25,7 @@ import { getTodayDateString, getYesterdayDateString, getDateRange } from "../lib
 import { DEFAULT_THEME, URL_CONST } from "../lib/core/constants.ts";
 import { chunkArray, BATCH_GET_CHUNK_SIZE } from "../lib/core/batch.ts";
 import { sendWebHook, WebHookMessages } from "../lib/core/webhook.ts";
+import { runCreateBatch, AlreadyExistsError } from "../lib/core/storage.ts";
 
 type Bindings = {
   DB: D1Database;
@@ -372,22 +373,33 @@ async function handleVisitAction(c: AppContext) {
     const hashedToken = await hashToken(token);
 
     // Create counter
-    await db.batch([
-      db
-        .prepare(
-          'INSERT INTO services (id, type, url, metadata, created_at) VALUES (?, ?, ?, ?, datetime("now"))'
-        )
-        .bind(`counter:${publicId}`, "counter", url, JSON.stringify({ webhookUrl })),
-      db
-        .prepare("INSERT INTO url_mappings (type, url, service_id) VALUES (?, ?, ?)")
-        .bind("counter", url, publicId),
-      db
-        .prepare("INSERT INTO owner_tokens (service_id, token_hash) VALUES (?, ?)")
-        .bind(`counter:${publicId}`, hashedToken),
-      db
-        .prepare("INSERT INTO counters (service_id, total) VALUES (?, 0)")
-        .bind(`counter:${publicId}:total`),
-    ]);
+    try {
+      await runCreateBatch(
+        db,
+        [
+          db
+            .prepare(
+              'INSERT INTO services (id, type, url, metadata, created_at) VALUES (?, ?, ?, ?, datetime("now"))'
+            )
+            .bind(`counter:${publicId}`, "counter", url, JSON.stringify({ webhookUrl })),
+          db
+            .prepare("INSERT INTO url_mappings (type, url, service_id) VALUES (?, ?, ?)")
+            .bind("counter", url, publicId),
+          db
+            .prepare("INSERT INTO owner_tokens (service_id, token_hash) VALUES (?, ?)")
+            .bind(`counter:${publicId}`, hashedToken),
+          db
+            .prepare("INSERT INTO counters (service_id, total) VALUES (?, 0)")
+            .bind(`counter:${publicId}:total`),
+        ],
+        "Counter already exists for this URL"
+      );
+    } catch (err) {
+      if (err instanceof AlreadyExistsError) {
+        return c.json({ error: err.message }, 400);
+      }
+      throw err;
+    }
 
     return c.json({
       success: true,
@@ -591,22 +603,35 @@ async function handleVisitAction(c: AppContext) {
 
       const metadata = JSON.stringify({ webhookUrl: null });
 
-      await db.batch([
-        db
-          .prepare(
-            'INSERT INTO services (id, type, url, metadata, created_at) VALUES (?, ?, ?, ?, datetime("now"))'
-          )
-          .bind(`counter:${item.id}`, "counter", item.url, metadata),
-        db
-          .prepare("INSERT INTO url_mappings (type, url, service_id) VALUES (?, ?, ?)")
-          .bind("counter", item.url, item.id),
-        db
-          .prepare("INSERT INTO owner_tokens (service_id, token_hash) VALUES (?, ?)")
-          .bind(`counter:${item.id}`, hashedToken),
-        db
-          .prepare("INSERT INTO counters (service_id, total) VALUES (?, 0)")
-          .bind(`counter:${item.id}:total`),
-      ]);
+      try {
+        await runCreateBatch(
+          db,
+          [
+            db
+              .prepare(
+                'INSERT INTO services (id, type, url, metadata, created_at) VALUES (?, ?, ?, ?, datetime("now"))'
+              )
+              .bind(`counter:${item.id}`, "counter", item.url, metadata),
+            db
+              .prepare("INSERT INTO url_mappings (type, url, service_id) VALUES (?, ?, ?)")
+              .bind("counter", item.url, item.id),
+            db
+              .prepare("INSERT INTO owner_tokens (service_id, token_hash) VALUES (?, ?)")
+              .bind(`counter:${item.id}`, hashedToken),
+            db
+              .prepare("INSERT INTO counters (service_id, total) VALUES (?, 0)")
+              .bind(`counter:${item.id}:total`),
+          ],
+          `Counter already exists: ${item.id}`
+        );
+      } catch (err) {
+        // 事前チェックと INSERT の間の競合は skip 扱い（既存の skip 意味論に合わせる）
+        if (err instanceof AlreadyExistsError) {
+          skipped++;
+          continue;
+        }
+        throw err;
+      }
       created++;
     }
 

--- a/apps/api/src/routes/yokoso.ts
+++ b/apps/api/src/routes/yokoso.ts
@@ -18,6 +18,7 @@ import type { Context } from "hono";
 import { hashToken, verifyToken, validateOwnerToken } from "../lib/core/auth.ts";
 import { generatePublicId } from "../lib/core/id.ts";
 import { sendWebHook, WebHookMessages } from "../lib/core/webhook.ts";
+import { runCreateBatch, AlreadyExistsError } from "../lib/core/storage.ts";
 import { LUCKY_CAT_DATA_URL } from "../assets/lucky-cat.ts";
 import { batchLookupServices, lookupService, MAX_LOOKUP_BATCH_SIZE } from "../lib/core/lookup.ts";
 
@@ -515,19 +516,30 @@ async function handleYokosoAction(c: AppContext) {
       updatedAt: now,
     });
 
-    await db.batch([
-      db
-        .prepare(
-          'INSERT INTO services (id, type, url, metadata, created_at) VALUES (?, ?, ?, ?, datetime("now"))'
-        )
-        .bind(`yokoso:${publicId}`, "yokoso", url, metadata),
-      db
-        .prepare("INSERT INTO url_mappings (type, url, service_id) VALUES (?, ?, ?)")
-        .bind("yokoso", url, publicId),
-      db
-        .prepare("INSERT INTO owner_tokens (service_id, token_hash) VALUES (?, ?)")
-        .bind(`yokoso:${publicId}`, hashedToken),
-    ]);
+    try {
+      await runCreateBatch(
+        db,
+        [
+          db
+            .prepare(
+              'INSERT INTO services (id, type, url, metadata, created_at) VALUES (?, ?, ?, ?, datetime("now"))'
+            )
+            .bind(`yokoso:${publicId}`, "yokoso", url, metadata),
+          db
+            .prepare("INSERT INTO url_mappings (type, url, service_id) VALUES (?, ?, ?)")
+            .bind("yokoso", url, publicId),
+          db
+            .prepare("INSERT INTO owner_tokens (service_id, token_hash) VALUES (?, ?)")
+            .bind(`yokoso:${publicId}`, hashedToken),
+        ],
+        "Yokoso already exists for this URL"
+      );
+    } catch (err) {
+      if (err instanceof AlreadyExistsError) {
+        return c.json({ error: err.message }, 400);
+      }
+      throw err;
+    }
 
     return c.json({
       success: true,

--- a/docs/user-guide/api.md
+++ b/docs/user-guide/api.md
@@ -85,6 +85,13 @@ All services support webhook functionality for real-time event notifications:
 3. **Manage**: URL + token for owner operations
 4. **Lookup**: URL + token → exists/id without loading service content
 
+### Error Responses
+
+All errors are returned as JSON.
+
+- **4xx**: `{"error": "<reason>"}` — e.g. `already exists`, validation failures
+- **500**: `{"error": "Internal Server Error"}` for unexpected server errors (always JSON, never text/plain)
+
 ## Try the Demos
 
 Visit our interactive demo pages to test all services:


### PR DESCRIPTION
## 関連 Issue
closes #21

## 変更内容
- **app.onError 追加**（index.ts）: 未捕捉例外を `console.error("[nostalgic-api] unhandled error:", method, path, action, err)` で記録し、500 応答を text/plain から JSON `{"error":"Internal Server Error"}` に統一。token 等の機微 query はログに出さない。今後 `wrangler tail` で原因が追える
- **lib/core/storage.ts 新設**: `runCreateBatch` が D1 の `UNIQUE constraint failed` を `AlreadyExistsError` に変換、他は透過。全5サービスの create に適用し、事前チェックとINSERTの間の競合を既存の already-exists 400 に正規化。visit/like の batchCreate は競合を skip 扱い（既存意味論維持）
- **テスト11件追加**（storage unit 4 + 結合 7）: 3分岐・400正規化・batchCreate skip・本物の app 経由の 500 JSON・ログに token が漏れないこと
- index.ts のルート import に `.ts` 拡張子を付与（routes 配下の既存スタイルに整合。テストで本物 app を import するために必要。lib/core の barrel 等は従来どおり拡張子なしのまま）

## 検証
- API テスト 39/39 pass（既存28 + 新規11）
- tsc --noEmit / lint 成功
- マージ後 `wrangler deploy` で本番反映し、create の golden path を実機確認予定
