### PR TITLE
fix: 案内文言を文単位で改行（コンテナ幅折返しの読みにくさを解消）

### DIFF
--- a/apps/web/public/components/bbs.js
+++ b/apps/web/public/components/bbs.js
@@ -51,10 +51,10 @@ const BBS_I18N = {
       "Failed to post message": "メッセージの投稿に失敗しました",
       "Failed to delete message": "メッセージの削除に失敗しました",
       "Rate limit exceeded. Please try again later.":
-        "アクセスが集中しています。しばらくしてからもう一度お試しください",
+        "アクセスが集中しています。\nしばらくしてからもう一度お試しください",
     },
     charLimitError: (n) => `メッセージは${n}文字以内で入力してください`,
-    rateLimitError: (n) => `連投制限中です。あと ${n} 秒待ってから投稿してください`,
+    rateLimitError: (n) => `連投制限中です。\nあと ${n} 秒待ってから投稿してください`,
   },
   en: {
     loading: "Loading...",
@@ -99,7 +99,7 @@ const BBS_I18N = {
       "Failed to post message": "Failed to post message",
       "Failed to delete message": "Failed to delete message",
       "Rate limit exceeded. Please try again later.":
-        "Rate limit exceeded. Please try again later.",
+        "Rate limit exceeded.\nPlease try again later.",
     },
     charLimitError: (n) => `Message must be ${n} characters or less`,
     rateLimitError: (n) => `Please wait ${n} seconds before posting again`,
@@ -919,6 +919,9 @@ class NostalgicBBS extends HTMLElement {
           border-radius: 2px;
           font-size: 13px;
           display: none;
+          /* 案内文は文単位（"。"区切り）で \n を挿入しているため、改行をそのまま反映する。
+             コンテナ幅で文の途中折返しになるのを防ぐ（Issue #26 オーナー実機指摘）。 */
+          white-space: pre-line;
         }
         .message-area.error {
           background: #ffebee;

--- a/apps/web/src/__tests__/bbsPostUX.test.ts
+++ b/apps/web/src/__tests__/bbsPostUX.test.ts
@@ -99,6 +99,14 @@ describe("bbs.js 成功表示の見た目", () => {
     expect(body).toMatch(/border:\s*[^;]*#2e7d32/i);
     expect(body).toMatch(/color:\s*#1b5e20/i);
   });
+
+  // 観点5-b: .message-area が white-space: pre-line を持つ（案内文の \n を文単位改行として反映）
+  test(".message-area が white-space: pre-line を持つ（文単位改行を反映）", () => {
+    const rule = bbsJs.match(/\.message-area\s*\{([\s\S]*?)\}/);
+    expect(rule).not.toBeNull();
+    const body = rule![1];
+    expect(body).toMatch(/white-space:\s*pre-line/i);
+  });
 });
 
 describe("bbs.js メッセージ自動消去タイマー", () => {
@@ -195,12 +203,31 @@ describe("配線: イベント名の相互一致", () => {
 // BBS.tsx: リロード誘導の購読
 // ---------------------------------------------------------------------------
 describe("BBS.tsx リロード誘導", () => {
-  // 観点10: ja / en のリロード誘導文言が定義されている
+  // 観点10: ja / en のリロード誘導文言が定義されている（文単位で行分割した配列）
   test("リロード誘導 posted 文言が ja / en 両方に定義されている", () => {
-    // embedTexts.ja.posted（日本語: 再読み込み誘導）
-    expect(bbsTsx).toMatch(/posted:\s*"[^"]*再読み込み[^"]*"/);
+    // embedTexts.ja.posted（日本語: 再読み込み誘導）— 文単位で配列化されていても拾える
+    expect(bbsTsx).toMatch(/posted:\s*\[[^\]]*再読み込み[^\]]*\]/);
     // embedTexts.en.posted（英語: reload 誘導）
-    expect(bbsTsx).toMatch(/posted:\s*"[^"]*reload[^"]*"/i);
+    expect(bbsTsx).toMatch(/posted:\s*\[[^\]]*reload[^\]]*\]/i);
+  });
+
+  // 観点10-b: posted は文単位で行分割した配列で、行ごとに描画される（途中折返し回避）
+  test("posted が配列（文単位で行分割）で定義されている", () => {
+    // ja / en それぞれ posted が配列リテラルで、2要素（2文）に分かれている
+    const arrays = bbsTsx.match(/posted:\s*\[([\s\S]*?)\]/g);
+    expect(arrays).not.toBeNull();
+    expect(arrays!.length).toBeGreaterThanOrEqual(2);
+    for (const arr of arrays!) {
+      // 各配列に文字列が2つ以上（"…", "…"）含まれる
+      const items = arr.match(/"[^"]*"/g);
+      expect(items).not.toBeNull();
+      expect(items!.length).toBeGreaterThanOrEqual(2);
+    }
+  });
+
+  test("posted を行ごとに描画している（map で <br /> を挟む）", () => {
+    expect(bbsTsx).toMatch(/t\.posted\.map\(/);
+    expect(bbsTsx).toMatch(/<br\s*\/>/);
   });
 
   test("embedPosted は useState(false) で初期非表示", () => {

--- a/apps/web/src/pages/BBS.tsx
+++ b/apps/web/src/pages/BBS.tsx
@@ -11,16 +11,18 @@ import { bbsEmbedConfig } from "../config/embedConfigs";
 import { API_BASE } from "../config/commonSteps";
 
 // 埋め込みページ用の多言語テキスト
+// posted は文単位（"。" / "!" 区切り）で行を分けて配列で持ち、行ごとに描画する。
+// コンテナ幅での文の途中折返しを避ける（Issue #26 オーナー実機指摘）。
 const embedTexts = {
   ja: {
     title: "ここにコメントを書き込んでください！",
     note: "※アカウント不要で誰でも書き込めます",
-    posted: "書き込みありがとうございます。元のページに戻って再読み込みすると反映されます。",
+    posted: ["書き込みありがとうございます。", "元のページに戻って再読み込みすると反映されます。"],
   },
   en: {
     title: "Leave a comment here!",
     note: "*No account required - anyone can post",
-    posted: "Thanks for posting! Go back to the original page and reload to see it reflected.",
+    posted: ["Thanks for posting!", "Go back to the original page and reload to see it reflected."],
   },
 };
 
@@ -525,7 +527,12 @@ export default function BBSPage() {
               padding: "10px 14px",
             }}
           >
-            {t.posted}
+            {t.posted.map((line, i) => (
+              <span key={i}>
+                {line}
+                {i < t.posted.length - 1 && <br />}
+              </span>
+            ))}
           </p>
         )}
         <p style={{ margin: 0, fontSize: "12px", color: "#999" }}>


### PR DESCRIPTION
## 関連 Issue
Refs #26（closed 後のオーナー実機指摘への追従）

## 変更内容
- bbs.js: `.message-area` に `white-space: pre-line` を追加し、2文以上の対訳（連投制限 ja・全体レート制限 ja/en）へ文末で `\n` を挿入
- BBS.tsx: リロード誘導を文単位の配列 + `<br />` 描画に変更（ja/en）
- テスト: regex を配列対応に更新 + pre-line / 配列構造の検査2件追加（393/393 pass）

## 検証
- web 393/393・build・lint・node --check 成功。マージ・デプロイ後に本番で2行表示を目視確認予定