### PR TITLE
docs: ブログコメント欄の埋め込み方式に静的SVG画像（JS不要）を明記

### DIFF
--- a/docs/user-guide/services/bbs.md
+++ b/docs/user-guide/services/bbs.md
@@ -520,7 +520,7 @@ document.addEventListener("nostalgic-bbs-posted", (e) => {
 
 ## Using BBS as a Blog Comment Section
 
-BBS works well as a comment section for static site blogs. Because each BBS is keyed to a URL, you can create one per post and embed it with the Web Component.
+BBS works well as a comment section for static site blogs. Because each BBS is keyed to a URL, you can create one per post and embed it with the Web Component, or as a static SVG image (`format=image`) that works without any JavaScript.
 
 [avel](https://github.com/kako-jun/avel), a Zola theme, is the reference implementation: it calls the `batchLookup` API at build time and auto-creates a BBS for every article. A step-by-step recipe for adding the same pattern to any other Zola theme (or static site generator) is available at [Comments on any Zola theme](https://avel.llll-ll.com/posts/comments-on-any-theme/).
 


### PR DESCRIPTION
PR #31 の追補。avel 方式の肝は Web Component ではなく静的 `<img>`（format=image・JS不要）なので、両方式を併記して正確化